### PR TITLE
Remove the "instance" field in LinkML validation errors

### DIFF
--- a/src/dandisets_linkml_status_tools/cli/models.py
+++ b/src/dandisets_linkml_status_tools/cli/models.py
@@ -4,6 +4,7 @@ from typing import Any
 from dandi.dandiapi import VersionStatus
 from linkml.validator.report import ValidationResult
 from pydantic import BaseModel, Json, TypeAdapter
+from typing_extensions import TypedDict  # Required for Python < 3.12 by Pydantic
 
 DandisetMetadataType = dict[str, Any]
 PydanticValidationErrsType = list[dict[str, Any]]
@@ -12,6 +13,17 @@ LinkmlValidationErrsType = list[ValidationResult]
 dandiset_metadata_adapter = TypeAdapter(DandisetMetadataType)
 pydantic_validation_errs_adapter = TypeAdapter(PydanticValidationErrsType)
 linkml_validation_errs_adapter = TypeAdapter(LinkmlValidationErrsType)
+
+# A `TypedDict` that has a key corresponding to each field in `ValidationResult`
+# except for the `instance` field
+TrimmedValidationResult = TypedDict(
+    "TrimmedValidationResult",
+    {
+        name: info.annotation
+        for name, info in ValidationResult.model_fields.items()
+        if name != "instance"
+    },
+)
 
 
 class DandisetValidationReport(BaseModel):

--- a/src/dandisets_linkml_status_tools/cli/models.py
+++ b/src/dandisets_linkml_status_tools/cli/models.py
@@ -1,18 +1,10 @@
 from datetime import datetime
-from typing import Any
+from typing import Annotated, Any
 
 from dandi.dandiapi import VersionStatus
 from linkml.validator.report import ValidationResult
-from pydantic import BaseModel, Json, TypeAdapter
+from pydantic import BaseModel, Json, PlainSerializer, TypeAdapter
 from typing_extensions import TypedDict  # Required for Python < 3.12 by Pydantic
-
-DandisetMetadataType = dict[str, Any]
-PydanticValidationErrsType = list[dict[str, Any]]
-LinkmlValidationErrsType = list[ValidationResult]
-
-dandiset_metadata_adapter = TypeAdapter(DandisetMetadataType)
-pydantic_validation_errs_adapter = TypeAdapter(PydanticValidationErrsType)
-linkml_validation_errs_adapter = TypeAdapter(LinkmlValidationErrsType)
 
 # A `TypedDict` that has a key corresponding to each field in `ValidationResult`
 # except for the `instance` field
@@ -24,6 +16,36 @@ TrimmedValidationResult = TypedDict(
         if name != "instance"
     },
 )
+
+
+def trim_validation_results(
+    errs: list[ValidationResult],
+) -> list[TrimmedValidationResult]:
+    """
+    Trim the `ValidationResult` objects in a list to exclude their `instance` field.
+
+    :param errs: The list of `ValidationResult` objects to be trimmed.
+
+    :return: The list of `TrimmedValidationResult` objects representing the trimmed
+        `ValidationResult` objects.
+    """
+    trimmed_errs = []
+    for err in errs:
+        err_as_dict = err.model_dump()
+        del err_as_dict["instance"]
+        trimmed_errs.append(err_as_dict)
+    return trimmed_errs
+
+
+DandisetMetadataType = dict[str, Any]
+PydanticValidationErrsType = list[dict[str, Any]]
+LinkmlValidationErrsType = Annotated[
+    list[ValidationResult], PlainSerializer(trim_validation_results)
+]
+
+dandiset_metadata_adapter = TypeAdapter(DandisetMetadataType)
+pydantic_validation_errs_adapter = TypeAdapter(PydanticValidationErrsType)
+linkml_validation_errs_adapter = TypeAdapter(LinkmlValidationErrsType)
 
 
 class DandisetValidationReport(BaseModel):


### PR DESCRIPTION
This PR removes the `"instance"` field in each LinkML validation error in serialization, and doing so in a way that the correct schema for the serialization is readily available.

For example, the printout of the following code snippet produces the subsequent schema in which `TrimmedValidationResult` has no `"instance"` property.

```py
import json

from dandisets_linkml_status_tools.cli.models import linkml_validation_errs_adapter

print(
    json.dumps(
        linkml_validation_errs_adapter.json_schema(mode="serialization"), indent=2
    )
)
```

```json
{
  "$defs": {
    "Severity": {
      "description": "Enum to represent the severity of a validation message.",
      "enum": [
        "FATAL",
        "ERROR",
        "WARN",
        "INFO"
      ],
      "title": "Severity",
      "type": "string"
    },
    "TrimmedValidationResult": {
      "properties": {
        "type": {
          "title": "Type",
          "type": "string"
        },
        "severity": {
          "$ref": "#/$defs/Severity"
        },
        "message": {
          "title": "Message",
          "type": "string"
        },
        "instance_index": {
          "anyOf": [
            {
              "type": "integer"
            },
            {
              "type": "null"
            }
          ],
          "title": "Instance Index"
        },
        "instantiates": {
          "anyOf": [
            {
              "type": "string"
            },
            {
              "type": "null"
            }
          ],
          "title": "Instantiates"
        },
        "context": {
          "items": {
            "type": "string"
          },
          "title": "Context",
          "type": "array"
        }
      },
      "required": [
        "type",
        "severity",
        "message",
        "instance_index",
        "instantiates",
        "context"
      ],
      "title": "TrimmedValidationResult",
      "type": "object"
    }
  },
  "items": {
    "$ref": "#/$defs/TrimmedValidationResult"
  },
  "type": "array"
}
```