### PR TITLE
Move generation of DANDI models in LinkML to module level

### DIFF
--- a/src/dandisets_linkml_status_tools/cli/tools.py
+++ b/src/dandisets_linkml_status_tools/cli/tools.py
@@ -35,6 +35,12 @@ from dandisets_linkml_status_tools.cli.models import (
 
 logger = logging.getLogger(__name__)
 
+# The names of the collection of modules in which the DANDI models are defined
+DANDI_MODULE_NAMES = ["dandischema.models"]
+
+# The LinkML schema produced by the pydantic2linkml translator for DANDI models
+DANDI_LINKML_SCHEMA = translate_defs(DANDI_MODULE_NAMES)
+
 # A callable that sorts a given iterable of strings in a case-insensitive manner
 isorted = partial(sorted, key=str.casefold)
 
@@ -74,15 +80,11 @@ class DandisetLinkmlValidator:
         the LinkML validator with. If no validation plugins are given, the default of a
         list containing a `JsonschemaValidationPlugin` instance with `closed=True`.
         """
-
-        # The names of the collection of modules in which the DANDI models are defined
-        dandiset_module_names = ["dandischema.models"]
-
         if validation_plugins is None:
             validation_plugins = [JsonschemaValidationPlugin(closed=True)]
 
         self._inner_validator = Validator(
-            translate_defs(dandiset_module_names),
+            DANDI_LINKML_SCHEMA,
             validation_plugins=validation_plugins,
         )
 


### PR DESCRIPTION
This improves performance by eliminating unneeded repeated calls to the generator.