### PR TITLE
Provide more detailed LinkML validation errors

### DIFF
--- a/src/dandisets_linkml_status_tools/cli/models.py
+++ b/src/dandisets_linkml_status_tools/cli/models.py
@@ -54,14 +54,14 @@ def polish_validation_results(
         `jsonschema.exceptions.ValidationError` object.
     """
     polished_errs = []
-    for err in results:
-        err_as_dict = err.model_dump()
+    for result in results:
+        err_as_dict = result.model_dump()
 
         # Remove the `instance` field
         del err_as_dict["instance"]
 
         # Include the `source` field as a `JsonValidationErrorView` object
-        result_source = err.source
+        result_source = result.source
         if not isinstance(result_source, ValidationError):
             msg = (
                 f"Expected `source` field of a `ValidationResult` object to be "

--- a/src/dandisets_linkml_status_tools/cli/models.py
+++ b/src/dandisets_linkml_status_tools/cli/models.py
@@ -34,7 +34,7 @@ PolishedValidationResult = TypedDict(
 
 
 def polish_validation_results(
-    errs: list[ValidationResult],
+    results: list[ValidationResult],
 ) -> list[PolishedValidationResult]:
     """
     Polish the `ValidationResult` objects in a list to exclude their `instance` field
@@ -45,7 +45,7 @@ def polish_validation_results(
     field of these `ValidationResult` objects is expected to be a
     `jsonschema.exceptions.ValidationError` object.
 
-    :param errs: The list of `ValidationResult` objects to be polished.
+    :param results: The list of `ValidationResult` objects to be polished.
 
     :return: The list of `PolishedValidationResult` objects representing the polished
         `ValidationResult` objects.
@@ -54,7 +54,7 @@ def polish_validation_results(
         `jsonschema.exceptions.ValidationError` object.
     """
     polished_errs = []
-    for err in errs:
+    for err in results:
         err_as_dict = err.model_dump()
 
         # Remove the `instance` field

--- a/src/dandisets_linkml_status_tools/cli/models.py
+++ b/src/dandisets_linkml_status_tools/cli/models.py
@@ -16,6 +16,7 @@ class JsonValidationErrorView(BaseModel):
     for serialization
     """
 
+    message: str
     absolute_path: Sequence[Union[str, int]]
     absolute_schema_path: Sequence[Union[str, int]]
     validator: str
@@ -72,6 +73,7 @@ def polish_validation_results(
             raise ValueError(msg)  # noqa: TRY004
         # noinspection PyTypeChecker
         result_as_dict["source"] = JsonValidationErrorView(
+            message=result_source.message,
             absolute_path=result_source.absolute_path,
             absolute_schema_path=result_source.absolute_schema_path,
             validator=result_source.validator,

--- a/src/dandisets_linkml_status_tools/cli/models.py
+++ b/src/dandisets_linkml_status_tools/cli/models.py
@@ -18,29 +18,32 @@ TrimmedValidationResult = TypedDict(
 )
 
 
-def trim_validation_results(
+def polish_validation_results(
     errs: list[ValidationResult],
 ) -> list[TrimmedValidationResult]:
     """
-    Trim the `ValidationResult` objects in a list to exclude their `instance` field.
+    Polish the `ValidationResult` objects in a list to exclude their `instance` field
+    and include their `source` field for serialization.
 
-    :param errs: The list of `ValidationResult` objects to be trimmed.
+    :param errs: The list of `ValidationResult` objects to be polished.
 
-    :return: The list of `TrimmedValidationResult` objects representing the trimmed
+    :return: The list of `TrimmedValidationResult` objects representing the polished
         `ValidationResult` objects.
     """
-    trimmed_errs = []
+    polished_errs = []
     for err in errs:
         err_as_dict = err.model_dump()
         del err_as_dict["instance"]
-        trimmed_errs.append(err_as_dict)
-    return trimmed_errs
+        err_as_dict["source"] = err.source
+
+        polished_errs.append(err_as_dict)
+    return polished_errs
 
 
 DandisetMetadataType = dict[str, Any]
 PydanticValidationErrsType = list[dict[str, Any]]
 LinkmlValidationErrsType = Annotated[
-    list[ValidationResult], PlainSerializer(trim_validation_results)
+    list[ValidationResult], PlainSerializer(polish_validation_results)
 ]
 
 dandiset_metadata_adapter = TypeAdapter(DandisetMetadataType)

--- a/src/dandisets_linkml_status_tools/cli/models.py
+++ b/src/dandisets_linkml_status_tools/cli/models.py
@@ -55,10 +55,10 @@ def polish_validation_results(
     """
     polished_errs = []
     for result in results:
-        err_as_dict = result.model_dump()
+        result_as_dict = result.model_dump()
 
         # Remove the `instance` field
-        del err_as_dict["instance"]
+        del result_as_dict["instance"]
 
         # Include the `source` field as a `JsonValidationErrorView` object
         result_source = result.source
@@ -68,12 +68,12 @@ def polish_validation_results(
                 f"a {ValidationError!r} object, but got {result_source!r}"
             )
             raise ValueError(msg)  # noqa: TRY004
-        err_as_dict["source"] = JsonValidationErrorView(
+        result_as_dict["source"] = JsonValidationErrorView(
             absolute_path=result_source.absolute_path,
             absolute_schema_path=result_source.absolute_schema_path,
         )
 
-        polished_errs.append(err_as_dict)
+        polished_errs.append(result_as_dict)
     return polished_errs
 
 

--- a/src/dandisets_linkml_status_tools/cli/models.py
+++ b/src/dandisets_linkml_status_tools/cli/models.py
@@ -18,6 +18,8 @@ class JsonValidationErrorView(BaseModel):
 
     absolute_path: Sequence[Union[str, int]]
     absolute_schema_path: Sequence[Union[str, int]]
+    validator: str
+    validator_value: Any
 
 
 # Build a `TypedDict` for representing a polished version of `ValidationResult`
@@ -68,9 +70,12 @@ def polish_validation_results(
                 f"a {ValidationError!r} object, but got {result_source!r}"
             )
             raise ValueError(msg)  # noqa: TRY004
+        # noinspection PyTypeChecker
         result_as_dict["source"] = JsonValidationErrorView(
             absolute_path=result_source.absolute_path,
             absolute_schema_path=result_source.absolute_schema_path,
+            validator=result_source.validator,
+            validator_value=result_source.validator_value,
         )
 
         polished_results.append(result_as_dict)

--- a/src/dandisets_linkml_status_tools/cli/models.py
+++ b/src/dandisets_linkml_status_tools/cli/models.py
@@ -53,7 +53,7 @@ def polish_validation_results(
     :raises ValueError: If the `source` field of a `ValidationResult` object is not a
         `jsonschema.exceptions.ValidationError` object.
     """
-    polished_errs = []
+    polished_results = []
     for result in results:
         result_as_dict = result.model_dump()
 
@@ -73,8 +73,8 @@ def polish_validation_results(
             absolute_schema_path=result_source.absolute_schema_path,
         )
 
-        polished_errs.append(result_as_dict)
-    return polished_errs
+        polished_results.append(result_as_dict)
+    return polished_results
 
 
 DandisetMetadataType = dict[str, Any]

--- a/src/dandisets_linkml_status_tools/cli/models.py
+++ b/src/dandisets_linkml_status_tools/cli/models.py
@@ -8,8 +8,8 @@ from typing_extensions import TypedDict  # Required for Python < 3.12 by Pydanti
 
 # A `TypedDict` that has a key corresponding to each field in `ValidationResult`
 # except for the `instance` field
-TrimmedValidationResult = TypedDict(
-    "TrimmedValidationResult",
+PolishedValidationResult = TypedDict(
+    "PolishedValidationResult",
     {
         name: info.annotation
         for name, info in ValidationResult.model_fields.items()
@@ -20,14 +20,14 @@ TrimmedValidationResult = TypedDict(
 
 def polish_validation_results(
     errs: list[ValidationResult],
-) -> list[TrimmedValidationResult]:
+) -> list[PolishedValidationResult]:
     """
     Polish the `ValidationResult` objects in a list to exclude their `instance` field
     and include their `source` field for serialization.
 
     :param errs: The list of `ValidationResult` objects to be polished.
 
-    :return: The list of `TrimmedValidationResult` objects representing the polished
+    :return: The list of `PolishedValidationResult` objects representing the polished
         `ValidationResult` objects.
     """
     polished_errs = []


### PR DESCRIPTION
This PR enables more detailed LinkML validation error info in the generated validation reports with the following features.

1. Precise locations of the cause of the error both in the data instance and schema.
2. Validator and validator value in causing the error

Note: This PR is based on the changes made in https://github.com/linkml/linkml/pull/2363. https://github.com/linkml/linkml/pull/2363 has been approved. Ideally, we should merge this PR after https://github.com/linkml/linkml/pull/2363 has been merged to LinkML's main branch. 

TODOs:

- [x] Include the locations, in the data instance and schema, of the cause of a validation error in the validation reports
- [x] Include validator and validator value in the reports
