### PR TITLE
Ensure fetching of subdirectories are in order

### DIFF
--- a/src/dandisets_linkml_status_tools/cli/__init__.py
+++ b/src/dandisets_linkml_status_tools/cli/__init__.py
@@ -21,7 +21,6 @@ from dandisets_linkml_status_tools.tools import (
     compile_dandiset_linkml_translation_report,
     create_or_replace_dir,
     get_direct_subdirs,
-    iter_direct_subdirs,
     output_reports,
     pydantic_validate,
     write_reports,
@@ -245,7 +244,7 @@ def manifests(
         # === In a dandiset directory ===
         dandiset_identifier = dandiset_dir.name
 
-        for version_dir in iter_direct_subdirs(dandiset_dir):
+        for version_dir in get_direct_subdirs(dandiset_dir):
             # === In a dandiset version directory ===
             dandiset_version = version_dir.name
 

--- a/src/dandisets_linkml_status_tools/cli/__init__.py
+++ b/src/dandisets_linkml_status_tools/cli/__init__.py
@@ -20,6 +20,7 @@ from dandisets_linkml_status_tools.models import (
 from dandisets_linkml_status_tools.tools import (
     compile_dandiset_linkml_translation_report,
     create_or_replace_dir,
+    get_direct_subdirs,
     iter_direct_subdirs,
     output_reports,
     pydantic_validate,
@@ -240,9 +241,7 @@ def manifests(
 
     dandiset_validation_reports: list[DandisetValidationReport] = []
     asset_validation_reports: list[AssetValidationReport] = []
-    for dandiset_dir in sorted(
-        iter_direct_subdirs(manifest_path), key=lambda p: p.name
-    ):
+    for dandiset_dir in get_direct_subdirs(manifest_path):
         # === In a dandiset directory ===
         dandiset_identifier = dandiset_dir.name
 

--- a/src/dandisets_linkml_status_tools/tools.py
+++ b/src/dandisets_linkml_status_tools/tools.py
@@ -48,7 +48,7 @@ DANDI_MODULE_NAMES = ["dandischema.models"]
 isorted = partial(sorted, key=str.casefold)
 
 
-def iter_direct_subdirs(path: Path) -> Iterable[Path]:
+def iter_direct_subdirs(dir_path: Path) -> Iterable[Path]:
     """
     Get an iterable of the direct subdirectories of a given path.
 
@@ -56,9 +56,9 @@ def iter_direct_subdirs(path: Path) -> Iterable[Path]:
     :return: The iterable of the direct subdirectories of the given path
     :raises: ValueError if the given path is not a directory
     """
-    if not path.is_dir():
-        raise ValueError(f"The given path is not a directory: {path}")
-    return (p for p in path.iterdir() if p.is_dir())
+    if not dir_path.is_dir():
+        raise ValueError(f"The given path is not a directory: {dir_path}")
+    return (p for p in dir_path.iterdir() if p.is_dir())
 
 
 def get_direct_subdirs(dir_path: Path) -> list[Path]:

--- a/src/dandisets_linkml_status_tools/tools.py
+++ b/src/dandisets_linkml_status_tools/tools.py
@@ -61,6 +61,18 @@ def iter_direct_subdirs(path: Path) -> Iterable[Path]:
     return (p for p in path.iterdir() if p.is_dir())
 
 
+def get_direct_subdirs(dir_path: Path) -> list[Path]:
+    """
+    Get a list of the direct subdirectories of a given directory
+
+    :param dir_path: The path of the given directory
+    :return: The list of the direct subdirectories of the given directory in sorted
+        order by the final component of their path
+    :raises: ValueError if the given path doesn't point to a directory
+    """
+    return sorted(iter_direct_subdirs(dir_path), key=lambda p: p.name)
+
+
 def pydantic_validate(data: DandiMetadata | str, model: type[BaseModel]) -> str:
     """
     Validate the given data against a Pydantic model

--- a/src/dandisets_linkml_status_tools/tools.py
+++ b/src/dandisets_linkml_status_tools/tools.py
@@ -50,11 +50,12 @@ isorted = partial(sorted, key=str.casefold)
 
 def iter_direct_subdirs(dir_path: Path) -> Iterable[Path]:
     """
-    Get an iterable of the direct subdirectories of a given path.
+    Get an iterable of the direct subdirectories of a given directory
 
-    :param path: The given path
-    :return: The iterable of the direct subdirectories of the given path
-    :raises: ValueError if the given path is not a directory
+    :param dir_path: The path of the given directory
+    :return: The iterable of the direct subdirectories of the given directory.
+        Note: The subdirectories are yielded in arbitrary order.
+    :raises: ValueError if the given path doesn't point to a directory
     """
     if not dir_path.is_dir():
         raise ValueError(f"The given path is not a directory: {dir_path}")


### PR DESCRIPTION
This PR ensure the fetching of subdirectories of a directory is in order in generating reports against manifests. In this way, entities specified in the reports will be in consistent order.