### PR TITLE
Organize validation reports to dicts

### DIFF
--- a/src/dandisets_linkml_status_tools/cli/__init__.py
+++ b/src/dandisets_linkml_status_tools/cli/__init__.py
@@ -153,9 +153,9 @@ def manifests(
         reports_dir_path / ASSET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME
     )
 
-    def append_dandiset_validation_report() -> None:
+    def add_dandiset_validation_report() -> None:
         """
-        Append a `DandisetValidationReport` object to `dandiset_validation_reports`
+        Add a `DandisetValidationReport` object to `dandiset_validation_reports`
         if the current dandiset version directory contains a dandiset metadata file.
         """
         dandiset_metadata_file_path = version_dir / DANDISET_FILE_NAME
@@ -252,7 +252,7 @@ def manifests(
             # === In a dandiset version directory ===
             dandiset_version = version_dir.name
 
-            append_dandiset_validation_report()
+            add_dandiset_validation_report()
             extend_asset_validation_reports()
 
     # Ensure directory for reports exists

--- a/src/dandisets_linkml_status_tools/cli/__init__.py
+++ b/src/dandisets_linkml_status_tools/cli/__init__.py
@@ -189,9 +189,9 @@ def manifests(
             dandiset_version,
         )
 
-    def extend_asset_validation_reports() -> None:
+    def add_asset_validation_reports() -> None:
         """
-        Extend `asset_validation_reports` with `AssetValidationReport` objects if the
+        Add `AssetValidationReport` objects to `asset_validation_reports` if the
         current dandiset version directory contains an assets metadata file.
         """
         assets_metadata_file_path = version_dir / ASSETS_FILE_NAME
@@ -253,7 +253,7 @@ def manifests(
             dandiset_version = version_dir.name
 
             add_dandiset_validation_report()
-            extend_asset_validation_reports()
+            add_asset_validation_reports()
 
     # Ensure directory for reports exists
     logger.info("Creating report directory: %s", reports_dir_path)

--- a/src/dandisets_linkml_status_tools/models.py
+++ b/src/dandisets_linkml_status_tools/models.py
@@ -243,6 +243,9 @@ ValidationReportsType: TypeAlias = defaultdict[str, dict[str, ValidationReport]]
 DandisetValidationReportsType: TypeAlias = defaultdict[
     str, Annotated[dict[str, DandisetValidationReport], Field(default_factory=dict)]
 ]
+AssetValidationReportsType: TypeAlias = defaultdict[
+    str, Annotated[dict[str, list[AssetValidationReport]], Field(default_factory=dict)]
+]
 
 # Type adapters for various types (this section should be at the end of this file)
 DANDI_METADATA_ADAPTER = TypeAdapter(DandiMetadata)
@@ -250,4 +253,4 @@ PYDANTIC_VALIDATION_ERRS_ADAPTER = TypeAdapter(PydanticValidationErrsType)
 LINKML_VALIDATION_ERRS_ADAPTER = TypeAdapter(LinkmlValidationErrsType)
 DANDI_METADATA_LIST_ADAPTER = TypeAdapter(list[DandiMetadata])
 DANDISET_VALIDATION_REPORTS_ADAPTER = TypeAdapter(DandisetValidationReportsType)
-ASSET_PYDANTIC_REPORT_LIST_ADAPTER = TypeAdapter(list[AssetValidationReport])
+ASSET_VALIDATION_REPORTS_ADAPTER = TypeAdapter(AssetValidationReportsType)

--- a/src/dandisets_linkml_status_tools/models.py
+++ b/src/dandisets_linkml_status_tools/models.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
@@ -6,7 +7,14 @@ from typing import Annotated, Any, NamedTuple, TypeAlias
 from dandi.dandiapi import VersionStatus
 from jsonschema import ValidationError
 from linkml.validator.report import ValidationResult
-from pydantic import AfterValidator, BaseModel, Json, PlainSerializer, TypeAdapter
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    Field,
+    Json,
+    PlainSerializer,
+    TypeAdapter,
+)
 from pydantic2linkml.cli.tools import LogLevel
 from typing_extensions import TypedDict  # Required for Python < 3.12 by Pydantic
 
@@ -231,10 +239,15 @@ class DandisetLinkmlTranslationReport(DandiBaseReport):
     linkml_validation_errs: LinkmlValidationErrsType = []
 
 
+ValidationReportsType: TypeAlias = defaultdict[str, dict[str, ValidationReport]]
+DandisetValidationReportsType: TypeAlias = defaultdict[
+    str, Annotated[dict[str, DandisetValidationReport], Field(default_factory=dict)]
+]
+
 # Type adapters for various types (this section should be at the end of this file)
 DANDI_METADATA_ADAPTER = TypeAdapter(DandiMetadata)
 PYDANTIC_VALIDATION_ERRS_ADAPTER = TypeAdapter(PydanticValidationErrsType)
 LINKML_VALIDATION_ERRS_ADAPTER = TypeAdapter(LinkmlValidationErrsType)
 DANDI_METADATA_LIST_ADAPTER = TypeAdapter(list[DandiMetadata])
-DANDISET_PYDANTIC_REPORT_LIST_ADAPTER = TypeAdapter(list[DandisetValidationReport])
+DANDISET_VALIDATION_REPORTS_ADAPTER = TypeAdapter(DandisetValidationReportsType)
 ASSET_PYDANTIC_REPORT_LIST_ADAPTER = TypeAdapter(list[AssetValidationReport])

--- a/src/dandisets_linkml_status_tools/models.py
+++ b/src/dandisets_linkml_status_tools/models.py
@@ -239,13 +239,15 @@ class DandisetLinkmlTranslationReport(DandiBaseReport):
     linkml_validation_errs: LinkmlValidationErrsType = []
 
 
-ValidationReportsType: TypeAlias = defaultdict[str, dict[str, ValidationReport]]
 DandisetValidationReportsType: TypeAlias = defaultdict[
     str, Annotated[dict[str, DandisetValidationReport], Field(default_factory=dict)]
 ]
 AssetValidationReportsType: TypeAlias = defaultdict[
     str, Annotated[dict[str, list[AssetValidationReport]], Field(default_factory=dict)]
 ]
+ValidationReportsType: TypeAlias = (
+    DandisetValidationReportsType | AssetValidationReportsType
+)
 
 # Type adapters for various types (this section should be at the end of this file)
 DANDI_METADATA_ADAPTER = TypeAdapter(DandiMetadata)

--- a/src/dandisets_linkml_status_tools/tools.py
+++ b/src/dandisets_linkml_status_tools/tools.py
@@ -29,7 +29,7 @@ from .models import (
     JsonschemaValidationErrorType,
     LinkmlValidationErrsType,
     PydanticValidationErrsType,
-    ValidationReport,
+    ValidationReportsType,
 )
 
 try:
@@ -99,14 +99,15 @@ def pydantic_validate(data: DandiMetadata | str, model: type[BaseModel]) -> str:
 
 
 def write_reports(
-    file_path: Path, reports: list[ValidationReport], type_adapter: TypeAdapter
+    file_path: Path, reports: ValidationReportsType, type_adapter: TypeAdapter
 ) -> None:
     """
-    Write a given list of validation reports to a specified file
+    Write a given collection of validation reports to a specified file
 
     :param file_path: The path specifying the file to write the reports to
-    :param reports: The list of validation reports to write
-    :param type_adapter: The type adapter to use for serializing the list of reports
+    :param reports: The collection of validation reports to write
+    :param type_adapter: The type adapter to use for serializing the collection of
+        reports
     """
     file_path.write_bytes(type_adapter.dump_json(reports, indent=2))
 


### PR DESCRIPTION
This PR organizes the validation reports generated by the subcommand `manifests` into dictionaries instead of lists. This allow easier look up of reports for a particular dandiset at a particular version