### PR TITLE
Add `diff-manifests-reports` subcommand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "dandi~=0.63",
   "dandischema>=0.10.2",
   "eval-type-backport>=0.2.0",
+  "jsondiff",
   "pydantic2linkml @ git+https://github.com/dandi/pydantic2linkml.git",
   "pyyaml>=6.0.2",
   "typer",

--- a/src/dandisets_linkml_status_tools/cli/__init__.py
+++ b/src/dandisets_linkml_status_tools/cli/__init__.py
@@ -131,16 +131,16 @@ MANIFESTS_REPORTS_SUBDIR = Path("manifests")
 DANDISET_FILE_NAME = "dandiset.jsonld"  # File with dandiset metadata
 ASSETS_FILE_NAME = "assets.jsonld"  # File with assets metadata
 
-DANDISET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME = "dandiset_validation_reports.json"
-ASSET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME = "asset_validation_reports.json"
+DANDISET_VALIDATION_REPORTS_FILE_NAME = "dandiset_validation_reports.json"
+ASSET_VALIDATION_REPORTS_FILE_NAME = "asset_validation_reports.json"
 
-# Relative path to the dandiset Pydantic validation reports file
+# Relative path to the dandiset validation reports file
 DANDISET_VALIDATION_REPORTS_FILE: Path = (
-    MANIFESTS_REPORTS_SUBDIR / DANDISET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME
+    MANIFESTS_REPORTS_SUBDIR / DANDISET_VALIDATION_REPORTS_FILE_NAME
 )
-# Relative path to the asset Pydantic validation reports file
+# Relative path to the asset validation reports file
 ASSET_VALIDATION_REPORTS_FILE: Path = (
-    MANIFESTS_REPORTS_SUBDIR / ASSET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME
+    MANIFESTS_REPORTS_SUBDIR / ASSET_VALIDATION_REPORTS_FILE_NAME
 )
 
 
@@ -158,12 +158,10 @@ def manifests(
     # Directory and file paths for reports
     output_dir: Path = config["output_dir_path"]
     reports_dir_path = output_dir / MANIFESTS_REPORTS_SUBDIR
-    dandiset_pydantic_validation_reports_file_path = (
+    dandiset_validation_reports_file_path = (
         output_dir / DANDISET_VALIDATION_REPORTS_FILE
     )
-    asset_pydantic_validation_reports_file_path = (
-        output_dir / ASSET_VALIDATION_REPORTS_FILE
-    )
+    asset_validation_reports_file_path = output_dir / ASSET_VALIDATION_REPORTS_FILE
 
     def add_dandiset_validation_report() -> None:
         """
@@ -279,16 +277,16 @@ def manifests(
     logger.info("Creating report directory: %s", reports_dir_path)
     create_or_replace_dir(reports_dir_path)
 
-    # Write the dandiset Pydantic validation reports to a file
+    # Write the dandiset validation reports to a file
     write_reports(
-        dandiset_pydantic_validation_reports_file_path,
+        dandiset_validation_reports_file_path,
         dandiset_validation_reports,
         DANDISET_VALIDATION_REPORTS_ADAPTER,
     )
 
-    # Write the asset Pydantic validation reports to a file
+    # Write the asset validation reports to a file
     write_reports(
-        asset_pydantic_validation_reports_file_path,
+        asset_validation_reports_file_path,
         asset_validation_reports,
         ASSET_VALIDATION_REPORTS_ADAPTER,
     )

--- a/src/dandisets_linkml_status_tools/cli/__init__.py
+++ b/src/dandisets_linkml_status_tools/cli/__init__.py
@@ -184,7 +184,6 @@ def manifests(
         dandiset_metadata = dandiset_metadata_file_path.read_text()
         pydantic_validation_errs = pydantic_validate(dandiset_metadata, model)
 
-        # noinspection PyTypeChecker
         dandiset_validation_reports[dandiset_identifier][dandiset_version] = (
             DandisetValidationReport(
                 dandiset_identifier=dandiset_identifier,
@@ -237,7 +236,6 @@ def manifests(
             asset_id = asset_metadata.get("id")
             asset_path = asset_metadata.get("path")
             pydantic_validation_errs = pydantic_validate(asset_metadata, model)
-            # noinspection PyTypeChecker
             reports_of_specific_dandiset_version.append(
                 AssetValidationReport(
                     dandiset_identifier=dandiset_identifier,

--- a/src/dandisets_linkml_status_tools/cli/__init__.py
+++ b/src/dandisets_linkml_status_tools/cli/__init__.py
@@ -131,10 +131,8 @@ MANIFESTS_REPORTS_SUBDIR = Path("manifests")
 DANDISET_FILE_NAME = "dandiset.jsonld"  # File with dandiset metadata
 ASSETS_FILE_NAME = "assets.jsonld"  # File with assets metadata
 
-DANDISET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME = (
-    "dandiset_pydantic_validation_reports.json"
-)
-ASSET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME = "asset_pydantic_validation_reports.json"
+DANDISET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME = "dandiset_validation_reports.json"
+ASSET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME = "asset_validation_reports.json"
 
 # Relative path to the dandiset Pydantic validation reports file
 DANDISET_VALIDATION_REPORTS_FILE: Path = (

--- a/src/dandisets_linkml_status_tools/cli/__init__.py
+++ b/src/dandisets_linkml_status_tools/cli/__init__.py
@@ -124,6 +124,9 @@ def linkml_translation(
     logger.info("Success!")
 
 
+# Subdirectory for reports on manifests
+MANIFESTS_REPORTS_SUBDIR = Path("manifests")
+
 # metadata file names
 DANDISET_FILE_NAME = "dandiset.jsonld"  # File with dandiset metadata
 ASSETS_FILE_NAME = "assets.jsonld"  # File with assets metadata
@@ -132,6 +135,15 @@ DANDISET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME = (
     "dandiset_pydantic_validation_reports.json"
 )
 ASSET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME = "asset_pydantic_validation_reports.json"
+
+# Relative path to the dandiset Pydantic validation reports file
+DANDISET_VALIDATION_REPORTS_FILE: Path = (
+    MANIFESTS_REPORTS_SUBDIR / DANDISET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME
+)
+# Relative path to the asset Pydantic validation reports file
+ASSET_VALIDATION_REPORTS_FILE: Path = (
+    MANIFESTS_REPORTS_SUBDIR / ASSET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME
+)
 
 
 @app.command()
@@ -146,12 +158,13 @@ def manifests(
     """
 
     # Directory and file paths for reports
-    reports_dir_path = config["output_dir_path"] / "manifests"
+    output_dir: Path = config["output_dir_path"]
+    reports_dir_path = output_dir / MANIFESTS_REPORTS_SUBDIR
     dandiset_pydantic_validation_reports_file_path = (
-        reports_dir_path / DANDISET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME
+        output_dir / DANDISET_VALIDATION_REPORTS_FILE
     )
     asset_pydantic_validation_reports_file_path = (
-        reports_dir_path / ASSET_PYDANTIC_VALIDATION_REPORTS_FILE_NAME
+        output_dir / ASSET_VALIDATION_REPORTS_FILE
     )
 
     def add_dandiset_validation_report() -> None:

--- a/src/dandisets_linkml_status_tools/cli/__init__.py
+++ b/src/dandisets_linkml_status_tools/cli/__init__.py
@@ -281,3 +281,25 @@ def manifests(
         asset_validation_reports,
         ASSET_VALIDATION_REPORTS_ADAPTER,
     )
+
+
+@app.command("diff-manifests-reports")
+def diff_manifests_reports_(
+    reports_dir1_path: Annotated[
+        Path,
+        typer.Argument(
+            help="Path of the directory containing the first set of reports for "
+            "contrast"
+        ),
+    ],
+    reports_dir2_path: Annotated[
+        Path,
+        typer.Argument(
+            help="Path of the directory containing the second set of reports for "
+            "contrast"
+        ),
+    ],
+):
+    """
+    Generate a report of differences between two sets of reports on the same manifests
+    """

--- a/src/dandisets_linkml_status_tools/cli/__init__.py
+++ b/src/dandisets_linkml_status_tools/cli/__init__.py
@@ -303,3 +303,10 @@ def diff_manifests_reports_(
     """
     Generate a report of differences between two sets of reports on the same manifests
     """
+    from dandisets_linkml_status_tools.cmd_funcs.diff_manifests_reports import (
+        diff_manifests_reports,
+    )
+
+    diff_manifests_reports(
+        reports_dir1_path, reports_dir2_path, config["output_dir_path"]
+    )

--- a/src/dandisets_linkml_status_tools/cmd_funcs/__init__.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/__init__.py
@@ -1,0 +1,1 @@
+# This package contains the functions that implement the individual commands of the CLI.

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -1,5 +1,8 @@
 import logging
 from pathlib import Path
+from typing import Annotated, Any
+
+from pydantic import Field
 
 from dandisets_linkml_status_tools.cli import (
     ASSET_VALIDATION_REPORTS_FILE,
@@ -9,11 +12,42 @@ from dandisets_linkml_status_tools.models import (
     ASSET_VALIDATION_REPORTS_ADAPTER,
     DANDISET_VALIDATION_REPORTS_ADAPTER,
     AssetValidationReportsType,
+    DandiBaseReport,
     DandisetValidationReportsType,
+    PydanticValidationErrsType,
 )
 from dandisets_linkml_status_tools.tools import read_reports
 
 logger = logging.getLogger(__name__)
+
+
+class _DandiValidationDiffReport(DandiBaseReport):
+    """
+    A base class for DANDI validation diff reports
+    """
+
+    pydantic_validation_errs1: Annotated[
+        PydanticValidationErrsType, Field(default_factory=list)
+    ]
+    pydantic_validation_errs2: Annotated[
+        PydanticValidationErrsType, Field(default_factory=list)
+    ]
+    pydantic_validation_errs_diff: Any
+
+
+class _DandisetValidationDiffReport(_DandiValidationDiffReport):
+    """
+    A class for Dandiset validation diff reports
+    """
+
+
+class _AssetValidationDiffReport(_DandiValidationDiffReport):
+    """
+    A class for Asset validation diff reports
+    """
+
+    asset_id: str | None
+    asset_path: str | None
 
 
 def diff_manifests_reports(

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -30,6 +30,8 @@ def diff_manifests_reports(
     """
     reports_dirs = [reports_dir1, reports_dir2]
 
+    dandiset_validation_reports_lst: list[DandisetValidationReportsType] = []
+    asset_validation_reports_lst: list[AssetValidationReportsType] = []
     for dir_ in reports_dirs:
         dandiset_validation_reports_file: Path = dir_ / DANDISET_VALIDATION_REPORTS_FILE
         asset_validation_reports_file: Path = dir_ / ASSET_VALIDATION_REPORTS_FILE
@@ -41,13 +43,17 @@ def diff_manifests_reports(
             if not f.is_file():
                 raise RuntimeError(f"There is no file at {f}")
 
-        # Load dandiset validation reports
-        dandiset_validation_reports: DandisetValidationReportsType = read_reports(
-            dandiset_validation_reports_file,
-            DANDISET_VALIDATION_REPORTS_ADAPTER,
+        # Load and store dandiset validation reports
+        dandiset_validation_reports_lst.append(
+            read_reports(
+                dandiset_validation_reports_file,
+                DANDISET_VALIDATION_REPORTS_ADAPTER,
+            )
         )
 
-        # Load asset validation reports
-        asset_validation_reports: AssetValidationReportsType = read_reports(
-            asset_validation_reports_file, ASSET_VALIDATION_REPORTS_ADAPTER
+        # Load and store asset validation reports
+        asset_validation_reports_lst.append(
+            read_reports(
+                asset_validation_reports_file, ASSET_VALIDATION_REPORTS_ADAPTER
+            )
         )

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def diff_manifests_reports(
+    reports_dir1: Path, reports_dir2: Path, output_dir: Path
+) -> None:
+    """
+    Generate a report of differences between two sets of reports on the same manifests
+
+    :param reports_dir1: Path of the directory containing the first set of reports
+        for contrast
+    :param reports_dir2: Path of the directory containing the second set of reports
+        for contrast
+    :param output_dir: Path of the directory to write the report of differences to
+    """

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -62,6 +62,8 @@ def diff_manifests_reports(
         for contrast
     :param output_dir: Path of the directory to write the report of differences to
     """
+    diff_reports_dir = output_dir / "diff_reports"
+
     reports_dirs = [reports_dir1, reports_dir2]
 
     dandiset_validation_reports_lst: list[DandisetValidationReportsType] = []
@@ -91,3 +93,9 @@ def diff_manifests_reports(
                 asset_validation_reports_file, ASSET_VALIDATION_REPORTS_ADAPTER
             )
         )
+
+    output_validation_diff_reports(
+        dandiset_validation_diff_reports_iter(*dandiset_validation_reports_lst),
+        asset_validation_diff_reports_iter(*asset_validation_reports_lst),
+        diff_reports_dir,
+    )

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -32,7 +32,7 @@ class _DandiValidationDiffReport(DandiBaseReport):
     pydantic_validation_errs2: Annotated[
         PydanticValidationErrsType, Field(default_factory=list)
     ]
-    pydantic_validation_errs_diff: Any
+    pydantic_validation_errs_diff: dict
 
 
 class _DandisetValidationDiffReport(_DandiValidationDiffReport):

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -42,11 +42,9 @@ def diff_manifests_reports(
                 raise FileNotFoundError(f"File {f} not found")
 
         # Load dandiset validation reports
-        dandiset_validation_reports: DandisetValidationReportsType = (
-            read_reports(
-                dandiset_validation_reports_file,
-                DANDISET_VALIDATION_REPORTS_ADAPTER,
-            )
+        dandiset_validation_reports: DandisetValidationReportsType = read_reports(
+            dandiset_validation_reports_file,
+            DANDISET_VALIDATION_REPORTS_ADAPTER,
         )
 
         # Load asset validation reports

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -1,4 +1,19 @@
+import logging
 from pathlib import Path
+
+from dandisets_linkml_status_tools.cli import (
+    ASSET_VALIDATION_REPORTS_FILE,
+    DANDISET_VALIDATION_REPORTS_FILE,
+)
+from dandisets_linkml_status_tools.models import (
+    ASSET_VALIDATION_REPORTS_ADAPTER,
+    DANDISET_VALIDATION_REPORTS_ADAPTER,
+    AssetValidationReportsType,
+    DandisetValidationReportsType,
+)
+from dandisets_linkml_status_tools.tools import read_reports
+
+logger = logging.getLogger(__name__)
 
 
 def diff_manifests_reports(
@@ -13,3 +28,28 @@ def diff_manifests_reports(
         for contrast
     :param output_dir: Path of the directory to write the report of differences to
     """
+    reports_dirs = [reports_dir1, reports_dir2]
+
+    for dir in reports_dirs:
+        dandiset_validation_reports_file: Path = dir / DANDISET_VALIDATION_REPORTS_FILE
+        asset_validation_reports_file: Path = dir / ASSET_VALIDATION_REPORTS_FILE
+
+        for f in [
+            dandiset_validation_reports_file,
+            asset_validation_reports_file,
+        ]:
+            if not f.is_file():
+                raise FileNotFoundError(f"File {f} not found")
+
+        # Load dandiset validation reports
+        dandiset_validation_reports: DandisetValidationReportsType = (
+            read_reports(
+                dandiset_validation_reports_file,
+                DANDISET_VALIDATION_REPORTS_ADAPTER,
+            )
+        )
+
+        # Load asset validation reports
+        asset_validation_reports: AssetValidationReportsType = read_reports(
+            asset_validation_reports_file, ASSET_VALIDATION_REPORTS_ADAPTER
+        )

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -39,7 +39,7 @@ def diff_manifests_reports(
             asset_validation_reports_file,
         ]:
             if not f.is_file():
-                raise FileNotFoundError(f"File {f} not found")
+                raise RuntimeError(f"There is no file at {f}")
 
         # Load dandiset validation reports
         dandiset_validation_reports: DandisetValidationReportsType = read_reports(

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -30,9 +30,9 @@ def diff_manifests_reports(
     """
     reports_dirs = [reports_dir1, reports_dir2]
 
-    for dir in reports_dirs:
-        dandiset_validation_reports_file: Path = dir / DANDISET_VALIDATION_REPORTS_FILE
-        asset_validation_reports_file: Path = dir / ASSET_VALIDATION_REPORTS_FILE
+    for dir_ in reports_dirs:
+        dandiset_validation_reports_file: Path = dir_ / DANDISET_VALIDATION_REPORTS_FILE
+        asset_validation_reports_file: Path = dir_ / ASSET_VALIDATION_REPORTS_FILE
 
         for f in [
             dandiset_validation_reports_file,

--- a/src/dandisets_linkml_status_tools/models.py
+++ b/src/dandisets_linkml_status_tools/models.py
@@ -11,7 +11,6 @@ from pydantic import (
     AfterValidator,
     BaseModel,
     Field,
-    Json,
     PlainSerializer,
     TypeAdapter,
 )

--- a/src/dandisets_linkml_status_tools/models.py
+++ b/src/dandisets_linkml_status_tools/models.py
@@ -115,7 +115,6 @@ def polish_validation_results(
 
         # Include the `source` field as a `JsonValidationErrorView` object
         result_source = result.source
-        # noinspection PyTypeChecker
         result_as_dict["source"] = JsonValidationErrorView(
             message=result_source.message,
             absolute_path=result_source.absolute_path,

--- a/src/dandisets_linkml_status_tools/models.py
+++ b/src/dandisets_linkml_status_tools/models.py
@@ -152,7 +152,7 @@ class ValidationReport(DandiBaseReport):
 
     # Error encountered in validation against a Pydantic model
     pydantic_validation_errs: Annotated[
-        Json[PydanticValidationErrsType], Field(default_factory=list)
+        PydanticValidationErrsType, Field(default_factory=list)
     ]
 
 
@@ -236,7 +236,7 @@ class DandisetLinkmlTranslationReport(DandiBaseReport):
 
     # Error encountered in validation against the Pydantic dandiset metadata model
     pydantic_validation_errs: Annotated[
-        Json[PydanticValidationErrsType], Field(default_factory=list)
+        PydanticValidationErrsType, Field(default_factory=list)
     ]
 
     # Errors encountered in validation against the dandiset metadata model in LinkML

--- a/src/dandisets_linkml_status_tools/tools.py
+++ b/src/dandisets_linkml_status_tools/tools.py
@@ -259,7 +259,6 @@ def compile_dandiset_linkml_translation_report(
             dandiset_version,
         )
 
-    # noinspection PyTypeChecker
     return DandisetLinkmlTranslationReport(
         dandiset_identifier=dandiset_id,
         dandiset_version=dandiset_version,

--- a/src/dandisets_linkml_status_tools/tools.py
+++ b/src/dandisets_linkml_status_tools/tools.py
@@ -410,8 +410,8 @@ def output_reports(
         summary_f.write("\n")
 
         # === Write the headers of the summary table ===
-        header_row = _gen_row(f" {h} " for h in summary_headers)
-        alignment_row = _gen_row("-" * (len(h) + 2) for h in summary_headers)
+        header_row = gen_row(f" {h} " for h in summary_headers)
+        alignment_row = gen_row("-" * (len(h) + 2) for h in summary_headers)
         summary_f.write(header_row + alignment_row)
 
         # Output the individual dandiset validation reports
@@ -478,7 +478,7 @@ def output_reports(
                     r.dandiset_schema_version,
                 ]
             )
-            summary_f.write(_gen_row(row_cells))
+            summary_f.write(gen_row(row_cells))
 
     logger.info("Output of dandiset validation reports completed")
 
@@ -528,7 +528,7 @@ def write_data(
         yaml_dump(serializable_data, f, Dumper=SafeDumper)
 
 
-def _gen_row(cell_str_values: Iterable[str]) -> str:
+def gen_row(cell_str_values: Iterable[str]) -> str:
     """
     Construct a row of a Markdown table with given cell string values
     :param cell_str_values: The given iterable of cell string values

--- a/src/dandisets_linkml_status_tools/tools.py
+++ b/src/dandisets_linkml_status_tools/tools.py
@@ -537,3 +537,20 @@ def _gen_row(cell_str_values: Iterable[str]) -> str:
     Note: The given iterable of cell string values are `str` values
     """
     return f'|{"|".join(cell_str_values)}|\n'
+
+
+def get_validation_reports_entries(
+    reports: ValidationReportsType,
+) -> set[tuple[str, str]]:
+    """
+    Obtain the entries of a collection of validation reports
+
+    :param reports: The collection of validation reports
+    :return: The entries of the collection of validation reports as a set of tuples
+        where each tuple contains the dandiset identifier and the dandiset version
+    """
+    entries = set()
+    for dandiset_id, reports_of_specific_dandiset_id in reports.items():
+        for dandiset_version in reports_of_specific_dandiset_id:
+            entries.add((dandiset_id, dandiset_version))
+    return entries

--- a/src/dandisets_linkml_status_tools/tools.py
+++ b/src/dandisets_linkml_status_tools/tools.py
@@ -112,6 +112,18 @@ def write_reports(
     file_path.write_bytes(type_adapter.dump_json(reports, indent=2))
 
 
+def read_reports(file: Path, type_adapter: TypeAdapter) -> ValidationReportsType:
+    """
+    Read a collection of validation reports from a specified file
+
+    :param file: The path of the file to read the reports from
+    :param type_adapter: The type adapter to use for deserializing the collection of
+        reports
+    :return: The collection of validation reports read from the file
+    """
+    return type_adapter.validate_json(file.read_bytes())
+
+
 class DandiModelLinkmlValidator:
     """
     A class to validate DANDI metadata against the DANDI metadata models in

--- a/src/dandisets_linkml_status_tools/tools.py
+++ b/src/dandisets_linkml_status_tools/tools.py
@@ -419,16 +419,16 @@ def output_reports(
             report_dir = output_path / r.dandiset_identifier / r.dandiset_version
             report_dir.mkdir(parents=True)
 
-            _write_data(
+            write_data(
                 r.dandiset_metadata, DANDI_METADATA_ADAPTER, "metadata", report_dir
             )
-            _write_data(
+            write_data(
                 r.pydantic_validation_errs,
                 PYDANTIC_VALIDATION_ERRS_ADAPTER,
                 "pydantic_validation_errs",
                 report_dir,
             )
-            _write_data(
+            write_data(
                 r.linkml_validation_errs,
                 LINKML_VALIDATION_ERRS_ADAPTER,
                 "linkml_validation_errs",
@@ -504,7 +504,7 @@ def create_or_replace_dir(dir_path: Path):
     logger.info("Created directory: %s", dir_path)
 
 
-def _write_data(
+def write_data(
     data: Any, data_adapter: TypeAdapter, base_file_name: str, output_dir: Path
 ) -> None:
     """

--- a/src/dandisets_linkml_status_tools/tools/__init__.py
+++ b/src/dandisets_linkml_status_tools/tools/__init__.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, TypeAdapter, ValidationError
 from pydantic2linkml.gen_linkml import translate_defs
 from yaml import dump as yaml_dump
 
-from .models import (
+from dandisets_linkml_status_tools.models import (
     DANDI_METADATA_ADAPTER,
     LINKML_VALIDATION_ERRS_ADAPTER,
     PYDANTIC_VALIDATION_ERRS_ADAPTER,

--- a/src/dandisets_linkml_status_tools/tools/__init__.py
+++ b/src/dandisets_linkml_status_tools/tools/__init__.py
@@ -33,6 +33,7 @@ from dandisets_linkml_status_tools.models import (
 )
 from dandisets_linkml_status_tools.tools.md import (
     gen_header_and_alignment_rows,
+    gen_pydantic_validation_errs_cell,
     gen_row,
 )
 
@@ -446,7 +447,6 @@ def output_reports(
             # at a particular version
             version_dir = f"{dandiset_dir}/{r.dandiset_version}"
 
-            pydantic_err_counts = get_pydantic_err_counts(r.pydantic_validation_errs)
             linkml_err_counts = get_linkml_err_counts(r.linkml_validation_errs)
 
             row_cells = (
@@ -457,12 +457,9 @@ def output_reports(
                     # For the version column
                     f"[{r.dandiset_version}]({version_dir}/metadata.yaml)",
                     # For the pydantic column
-                    (
-                        f"[{len(r.pydantic_validation_errs)} "
-                        f"({', '.join(f'{v} {k}' for k, v in pydantic_err_counts.items())})]"
-                        f"({version_dir}/pydantic_validation_errs.yaml)"
-                        if r.pydantic_validation_errs
-                        else "0"
+                    gen_pydantic_validation_errs_cell(
+                        r.pydantic_validation_errs,
+                        f"{version_dir}/pydantic_validation_errs.yaml",
                     ),
                     # For the linkml column
                     (

--- a/src/dandisets_linkml_status_tools/tools/__init__.py
+++ b/src/dandisets_linkml_status_tools/tools/__init__.py
@@ -31,7 +31,10 @@ from dandisets_linkml_status_tools.models import (
     PydanticValidationErrsType,
     ValidationReportsType,
 )
-from dandisets_linkml_status_tools.tools.md import gen_row
+from dandisets_linkml_status_tools.tools.md import (
+    gen_header_and_alignment_rows,
+    gen_row,
+)
 
 try:
     # Import the C-based YAML dumper if available
@@ -410,10 +413,8 @@ def output_reports(
         # Write line break before the start of the summary table
         summary_f.write("\n")
 
-        # === Write the headers of the summary table ===
-        header_row = gen_row(f" {h} " for h in summary_headers)
-        alignment_row = gen_row("-" * (len(h) + 2) for h in summary_headers)
-        summary_f.write(header_row + alignment_row)
+        # Write the header and alignment rows of the summary table
+        summary_f.write(gen_header_and_alignment_rows(summary_headers))
 
         # Output the individual dandiset validation reports
         for r in reports:

--- a/src/dandisets_linkml_status_tools/tools/__init__.py
+++ b/src/dandisets_linkml_status_tools/tools/__init__.py
@@ -425,18 +425,20 @@ def output_reports(
             write_data(
                 r.dandiset_metadata, report_dir, "metadata", DANDI_METADATA_ADAPTER
             )
-            write_data(
-                r.pydantic_validation_errs,
-                report_dir,
-                "pydantic_validation_errs",
-                PYDANTIC_VALIDATION_ERRS_ADAPTER,
-            )
-            write_data(
-                r.linkml_validation_errs,
-                report_dir,
-                "linkml_validation_errs",
-                LINKML_VALIDATION_ERRS_ADAPTER,
-            )
+            if r.pydantic_validation_errs:
+                write_data(
+                    r.pydantic_validation_errs,
+                    report_dir,
+                    "pydantic_validation_errs",
+                    PYDANTIC_VALIDATION_ERRS_ADAPTER,
+                )
+            if r.linkml_validation_errs:
+                write_data(
+                    r.linkml_validation_errs,
+                    report_dir,
+                    "linkml_validation_errs",
+                    LINKML_VALIDATION_ERRS_ADAPTER,
+                )
 
             logger.info("Output dandiset %s validation report", r.dandiset_identifier)
 

--- a/src/dandisets_linkml_status_tools/tools/__init__.py
+++ b/src/dandisets_linkml_status_tools/tools/__init__.py
@@ -31,6 +31,7 @@ from dandisets_linkml_status_tools.models import (
     PydanticValidationErrsType,
     ValidationReportsType,
 )
+from dandisets_linkml_status_tools.tools.md import gen_row
 
 try:
     # Import the C-based YAML dumper if available
@@ -526,17 +527,6 @@ def write_data(
     yaml_file_path = output_dir / (base_file_name + ".yaml")
     with yaml_file_path.open("w") as f:
         yaml_dump(serializable_data, f, Dumper=SafeDumper)
-
-
-def gen_row(cell_str_values: Iterable[str]) -> str:
-    """
-    Construct a row of a Markdown table with given cell string values
-    :param cell_str_values: The given iterable of cell string values
-    :return: The constructed row of a Markdown table
-
-    Note: The given iterable of cell string values are `str` values
-    """
-    return f'|{"|".join(cell_str_values)}|\n'
 
 
 def get_validation_reports_entries(

--- a/src/dandisets_linkml_status_tools/tools/__init__.py
+++ b/src/dandisets_linkml_status_tools/tools/__init__.py
@@ -422,19 +422,19 @@ def output_reports(
             report_dir.mkdir(parents=True)
 
             write_data(
-                r.dandiset_metadata, DANDI_METADATA_ADAPTER, "metadata", report_dir
+                r.dandiset_metadata, report_dir, "metadata", DANDI_METADATA_ADAPTER
             )
             write_data(
                 r.pydantic_validation_errs,
-                PYDANTIC_VALIDATION_ERRS_ADAPTER,
-                "pydantic_validation_errs",
                 report_dir,
+                "pydantic_validation_errs",
+                PYDANTIC_VALIDATION_ERRS_ADAPTER,
             )
             write_data(
                 r.linkml_validation_errs,
-                LINKML_VALIDATION_ERRS_ADAPTER,
-                "linkml_validation_errs",
                 report_dir,
+                "linkml_validation_errs",
+                LINKML_VALIDATION_ERRS_ADAPTER,
             )
 
             logger.info("Output dandiset %s validation report", r.dandiset_identifier)
@@ -507,17 +507,24 @@ def create_or_replace_dir(dir_path: Path):
 
 
 def write_data(
-    data: Any, data_adapter: TypeAdapter, base_file_name: str, output_dir: Path
+    data: Any,
+    output_dir: Path,
+    base_file_name: str,
+    data_adapter: TypeAdapter | None = None,
 ) -> None:
     """
     Output given data to a JSON file and a YAML file in a given output directory
 
     :param data: The data to be output
-    :param data_adapter: The type adapter used to serialize the data
-    :param base_file_name: The base file name for the output files
     :param output_dir: The output directory to write the files to
+    :param base_file_name: The base file name for the output files
+    :param data_adapter: The type adapter used to serialize the data.
+        If `None`, the data is considered to be a JSON-serializable Python object.
     """
-    serializable_data = data_adapter.dump_python(data, mode="json")
+    if data_adapter is None:
+        serializable_data = data
+    else:
+        serializable_data = data_adapter.dump_python(data, mode="json")
 
     # Output data to a JSON file
     json_file_path = output_dir / (base_file_name + ".json")

--- a/src/dandisets_linkml_status_tools/tools/md.py
+++ b/src/dandisets_linkml_status_tools/tools/md.py
@@ -1,4 +1,5 @@
 # This file contains helpers for generating Markdown files
+
 from collections.abc import Iterable
 
 from dandisets_linkml_status_tools.models import PydanticValidationErrsType
@@ -48,3 +49,15 @@ def gen_pydantic_validation_errs_cell(
         if errs
         else "0"
     )
+
+
+def gen_diff_cell(diff: dict | list, diff_file: str) -> str:
+    """
+    Generate the content of a cell representing a diff in a table in a Markdown file
+
+    :param diff: The diff to be represented
+    :param diff_file: The relative path, from the Markdown file, to the file containing
+        the diff
+    :return: The content of the cell
+    """
+    return f"[**DIFFERENT**]({diff_file})" if diff else "same"

--- a/src/dandisets_linkml_status_tools/tools/md.py
+++ b/src/dandisets_linkml_status_tools/tools/md.py
@@ -11,3 +11,15 @@ def gen_row(cell_str_values: Iterable[str]) -> str:
     Note: The given iterable of cell string values are `str` values
     """
     return f'|{"|".join(cell_str_values)}|\n'
+
+
+def gen_header_and_alignment_rows(headers: Iterable[str]) -> str:
+    """
+    Generate a header row and an alignment row for a Markdown table
+
+    :return: The string containing the header row followed by the alignment row
+    """
+
+    header_row = gen_row(f" {h} " for h in headers)
+    alignment_row = gen_row("-" * (len(h) + 2) for h in headers)
+    return header_row + alignment_row

--- a/src/dandisets_linkml_status_tools/tools/md.py
+++ b/src/dandisets_linkml_status_tools/tools/md.py
@@ -1,0 +1,13 @@
+# This file contains helpers for generating Markdown files
+from collections.abc import Iterable
+
+
+def gen_row(cell_str_values: Iterable[str]) -> str:
+    """
+    Construct a row of a Markdown table with given cell string values
+    :param cell_str_values: The given iterable of cell string values
+    :return: The constructed row of a Markdown table
+
+    Note: The given iterable of cell string values are `str` values
+    """
+    return f'|{"|".join(cell_str_values)}|\n'

--- a/src/dandisets_linkml_status_tools/tools/md.py
+++ b/src/dandisets_linkml_status_tools/tools/md.py
@@ -1,6 +1,8 @@
 # This file contains helpers for generating Markdown files
 from collections.abc import Iterable
 
+from dandisets_linkml_status_tools.models import PydanticValidationErrsType
+
 
 def gen_row(cell_str_values: Iterable[str]) -> str:
     """
@@ -23,3 +25,26 @@ def gen_header_and_alignment_rows(headers: Iterable[str]) -> str:
     header_row = gen_row(f" {h} " for h in headers)
     alignment_row = gen_row("-" * (len(h) + 2) for h in headers)
     return header_row + alignment_row
+
+
+def gen_pydantic_validation_errs_cell(
+    errs: PydanticValidationErrsType, errs_file: str
+) -> str:
+    """
+    Generate the content of a cell representing Pydantic validation errors in a table
+    in a Markdown file
+
+    :param errs: The collection of Pydantic validation errors to be represented
+    :param errs_file: The relative path, from the Markdown file, to the file containing
+        the Pydantic validation errors
+    :return: The content of the cell
+    """
+    from dandisets_linkml_status_tools.tools import get_pydantic_err_counts
+
+    return (
+        f"[{len(errs)} "
+        f"({', '.join(f'{v} {k}' for k, v in get_pydantic_err_counts(errs).items())})]"
+        f"({errs_file})"
+        if errs
+        else "0"
+    )

--- a/tests/test_cli/test_tools.py
+++ b/tests/test_cli/test_tools.py
@@ -63,7 +63,6 @@ def test_get_linkml_err_counts(
     """
     errs = []
     for t in error_types:
-        # noinspection PyTypeChecker
         jsonschema_validation_error = ValidationError(
             message="An artificial error",
             validator=t.validator,


### PR DESCRIPTION
This PR adds the `diff-manifests-reports` subcommand to generate dandiset Pydantic validation diff reports of two manifests reports ( reports output by the `manifests` subcommand).

Incidentally, this PR modifies the reports output by `manifests` subcommand so that they don't contain any validation reports which don't contain any validation error, i.e. this PR closes #43.