### PR TITLE
Simplify the serialization of collection of asset validation reports

### DIFF
--- a/src/dandisets_linkml_status_tools/cli/__init__.py
+++ b/src/dandisets_linkml_status_tools/cli/__init__.py
@@ -257,18 +257,17 @@ def manifests(
                     dandiset_version=dandiset_version,
                     asset_id=asset_id,
                     asset_path=asset_path,
+                    asset_idx=idx,
                     pydantic_validation_errs=pydantic_validation_errs,
                 )
-                asset_validation_reports[
-                    Path(dandiset_identifier, dandiset_version, str(idx))
-                ] = r
+                asset_validation_reports.append(r)
 
                 logger.info(
                     "Dandiset %s:%s: Added validation report for asset %sat index %d",
-                    dandiset_identifier,
-                    dandiset_version,
+                    r.dandiset_identifier,
+                    r.dandiset_version,
                     f"{r.asset_id} " if r.asset_id else "",
-                    idx,
+                    r.asset_idx,
                 )
 
     dandiset_validation_reports: DandisetValidationReportsType = defaultdict(dict)

--- a/src/dandisets_linkml_status_tools/models.py
+++ b/src/dandisets_linkml_status_tools/models.py
@@ -171,6 +171,7 @@ class AssetValidationReport(ValidationReport):
 
     asset_id: str | None
     asset_path: str | None
+    asset_idx: int  # Index of the asset in the array in the `assets.jsonld` file
 
 
 class JsonschemaValidationErrorType(NamedTuple):
@@ -246,7 +247,7 @@ class DandisetLinkmlTranslationReport(DandiBaseReport):
 DandisetValidationReportsType: TypeAlias = defaultdict[
     str, Annotated[dict[str, DandisetValidationReport], Field(default_factory=dict)]
 ]
-AssetValidationReportsType: TypeAlias = dict[Path, AssetValidationReport]
+AssetValidationReportsType: TypeAlias = list[AssetValidationReport]
 ValidationReportsType: TypeAlias = (
     DandisetValidationReportsType | AssetValidationReportsType
 )

--- a/src/dandisets_linkml_status_tools/models.py
+++ b/src/dandisets_linkml_status_tools/models.py
@@ -243,16 +243,6 @@ class DandisetLinkmlTranslationReport(DandiBaseReport):
     ]
 
 
-class AssetManifestsPath(NamedTuple):
-    """
-    The path of an asset metadata instance located in a manifests directory
-    """
-
-    dandiset_id: str  # Identify the 1st level subdir
-    dandiset_ver: str  # Identify the 2nd level subdir
-    array_idx: int  # Index of the instance in the array in the `assets.jsonld` file
-
-
 DandisetValidationReportsType: TypeAlias = defaultdict[
     str, Annotated[dict[str, DandisetValidationReport], Field(default_factory=dict)]
 ]


### PR DESCRIPTION
This PR simplifies serialization of the collection of asset validation reports outputted by the `manifests` subcommand and allows the `diff-manifests-reports` to use this new format of serialization correctly.