### PR TITLE
Add support of generating diff reports for jsonschema validation errors

### DIFF
--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from itertools import chain
 from pathlib import Path
 from typing import Annotated, Any, TypeAlias, cast
@@ -633,6 +633,23 @@ def err_reps(
     )
 
 
+def count_validation_errs(
+    err_reps_: Iterable[tuple], err_categorizer: Callable[[Any], tuple]
+) -> ValidationErrCounter:
+    """
+    Count validation errors represented by tuples
+
+    :param err_reps_: The validation errors represented as tuples
+    :param err_categorizer: A function that categorizes validation errors, represented
+        by tuples, into categories, also represented by tuples
+    :return: A `ValidationErrCounter` object representing the counts
+    """
+    ctr = ValidationErrCounter(err_categorizer)
+    ctr.count(err_reps_)
+
+    return ctr
+
+
 def count_pydantic_validation_errs(
     err_reps_: Iterable[PydanticValidationErrRep],
 ) -> ValidationErrCounter:
@@ -643,7 +660,4 @@ def count_pydantic_validation_errs(
         defined by the output of `pydantic_err_rep`
     :return: A `ValidationErrCounter` object representing the counts
     """
-    ctr = ValidationErrCounter(pydantic_err_categorizer)
-    ctr.count(err_reps_)
-
-    return ctr
+    return count_validation_errs(err_reps_, pydantic_err_categorizer)

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -163,15 +163,24 @@ def _dandiset_validation_diff_reports(
         r1 = reports1.get(id_, {}).get(ver, None)
         r2 = reports2.get(id_, {}).get(ver, None)
 
-        # If both are None, skip this entry
-        if r1 is None and r2 is None:
-            continue
+        if r1 is not None:
+            pydantic_errs1 = r1.pydantic_validation_errs
+            jsonschema_errs1 = r1.jsonschema_validation_errs
+        else:
+            pydantic_errs1 = []
+            jsonschema_errs1 = []
 
-        pydantic_errs1 = r1.pydantic_validation_errs if r1 is not None else []
-        pydantic_errs2 = r2.pydantic_validation_errs if r2 is not None else []
+        if r2 is not None:
+            pydantic_errs2 = r2.pydantic_validation_errs
+            jsonschema_errs2 = r2.jsonschema_validation_errs
+        else:
+            pydantic_errs2 = []
+            jsonschema_errs2 = []
 
         # If all errs are empty, skip this entry
-        if not any([pydantic_errs1, pydantic_errs2]):
+        if not any(
+            (pydantic_errs1, pydantic_errs2, jsonschema_errs1, jsonschema_errs2)
+        ):
             continue
 
         rs.append(
@@ -180,8 +189,15 @@ def _dandiset_validation_diff_reports(
                 dandiset_version=ver,
                 pydantic_validation_errs1=pydantic_errs1,
                 pydantic_validation_errs2=pydantic_errs2,
-                pydantic_validation_errs_diff=(
-                    diff(pydantic_errs1, pydantic_errs2, marshal=True)
+                pydantic_validation_errs_diff=diff(
+                    pydantic_errs1, pydantic_errs2, marshal=True
+                ),
+                jsonschema_validation_errs1=jsonschema_errs1,
+                jsonschema_validation_errs2=jsonschema_errs2,
+                jsonschema_validation_errs_diff=diff(
+                    [e.model_dump(mode="json") for e in jsonschema_errs1],
+                    [e.model_dump(mode="json") for e in jsonschema_errs2],
+                    marshal=True,
                 ),
             )
         )
@@ -213,11 +229,24 @@ def _asset_validation_diff_reports(
         r1 = rs1.get(entry)
         r2 = rs2.get(entry)
 
-        pydantic_errs1 = r1.pydantic_validation_errs if r1 is not None else []
-        pydantic_errs2 = r2.pydantic_validation_errs if r2 is not None else []
+        if r1 is not None:
+            pydantic_errs1 = r1.pydantic_validation_errs
+            jsonschema_errs1 = r1.jsonschema_validation_errs
+        else:
+            pydantic_errs1 = []
+            jsonschema_errs1 = []
+
+        if r2 is not None:
+            pydantic_errs2 = r2.pydantic_validation_errs
+            jsonschema_errs2 = r2.jsonschema_validation_errs
+        else:
+            pydantic_errs2 = []
+            jsonschema_errs2 = []
 
         # If all errs are empty, skip this entry
-        if not any([pydantic_errs1, pydantic_errs2]):
+        if not any(
+            (pydantic_errs1, pydantic_errs2, jsonschema_errs1, jsonschema_errs2)
+        ):
             continue
 
         asset_id = r1.asset_id if r1 is not None else r2.asset_id
@@ -235,6 +264,13 @@ def _asset_validation_diff_reports(
                 pydantic_validation_errs2=pydantic_errs2,
                 pydantic_validation_errs_diff=diff(
                     pydantic_errs1, pydantic_errs2, marshal=True
+                ),
+                jsonschema_validation_errs1=jsonschema_errs1,
+                jsonschema_validation_errs2=jsonschema_errs2,
+                jsonschema_validation_errs_diff=diff(
+                    [e.model_dump(mode="json") for e in jsonschema_errs1],
+                    [e.model_dump(mode="json") for e in jsonschema_errs2],
+                    marshal=True,
                 ),
             )
         )

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -29,7 +29,11 @@ from dandisets_linkml_status_tools.tools import (
     read_reports,
     write_data,
 )
-from dandisets_linkml_status_tools.tools.md import pydantic_validation_err_diff_summary
+from dandisets_linkml_status_tools.tools.md import (
+    jsonschema_validation_err_diff_detailed_table,
+    pydantic_validation_err_diff_detailed_table,
+    validation_err_diff_summary,
+)
 from dandisets_linkml_status_tools.tools.validation_err_counter import (
     ValidationErrCounter,
 )
@@ -370,6 +374,17 @@ def _output_dandiset_validation_diff_reports(
 
     with (output_dir / PYDANTIC_ERRS_SUMMARY_FNAME).open("w") as summary_f:
         # Write the summary of the Pydantic validation error differences
+        # noinspection PyTypeChecker
+        summary_f.write(
+            validation_err_diff_summary(
+                pydantic_validation_errs1_ctr,
+                pydantic_validation_errs2_ctr,
+                pydantic_validation_err_diff_detailed_table,
+            )
+        )
+
+    with (output_dir / JSONSCHEMA_ERRS_SUMMARY_FNAME).open("w") as summary_f:
+        # Write the summary of the JSON schema validation error differences
         summary_f.write(
             pydantic_validation_err_diff_summary(
                 pydantic_validation_errs1_ctr, pydantic_validation_errs2_ctr
@@ -422,9 +437,14 @@ def _output_asset_validation_diff_reports(
 
     with (output_dir / PYDANTIC_ERRS_SUMMARY_FNAME).open("w") as summary_f:
         # Write the summary of the Pydantic validation error differences
+        # noinspection PyTypeChecker
         summary_f.write(
-            pydantic_validation_err_diff_summary(
-                pydantic_validation_errs1_ctr, pydantic_validation_errs2_ctr
+            validation_err_diff_summary(
+                pydantic_validation_errs1_ctr,
+                pydantic_validation_errs2_ctr,
+                pydantic_validation_err_diff_detailed_table,
+            )
+        )
             )
         )
 

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -514,8 +514,8 @@ def jsonschema_err_categorizer(
     """
     err_model = err[0]
     # Categorize the "absolute_path" by replacing all array indices with "[*]"
-    categorized_absolute_path = (
-        tuple("[*]" if isinstance(v, int) else v for v in err_model.absolute_path),
+    categorized_absolute_path = tuple(
+        "[*]" if isinstance(v, int) else v for v in err_model.absolute_path
     )
 
     return err_model.message, err_model.absolute_schema_path, categorized_absolute_path

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -39,6 +39,8 @@ logger = logging.getLogger(__name__)
 PydanticValidationErrRep: TypeAlias = tuple[str, str, tuple, Path]
 JsonschemaValidationErrRep: TypeAlias = tuple[JsonschemaValidationErrorModel, Path]
 
+PYDANTIC_ERRS_SUMMARY_FNAME = "pydantic_errs_summary.md"
+
 
 class _DandiValidationDiffReport(DandiBaseReport):
     """
@@ -347,8 +349,6 @@ def _output_dandiset_validation_diff_reports(
     :param reports: The reports to be output
     :param output_dir: Path of the directory to write the reports to
     """
-    summary_file_name = "summary.md"
-
     logger.info("Creating dandiset validation diff report directory %s", output_dir)
     output_dir.mkdir(parents=True)
 
@@ -368,7 +368,7 @@ def _output_dandiset_validation_diff_reports(
         jsonschema_err2_reps
     )
 
-    with (output_dir / summary_file_name).open("w") as summary_f:
+    with (output_dir / PYDANTIC_ERRS_SUMMARY_FNAME).open("w") as summary_f:
         # Write the summary of the Pydantic validation error differences
         summary_f.write(
             pydantic_validation_err_diff_summary(
@@ -401,8 +401,6 @@ def _output_asset_validation_diff_reports(
     :param reports: The reports to be output
     :param output_dir: Path of the directory to write the reports to
     """
-    summary_file_name = "summary.md"
-
     output_dir.mkdir(parents=True)
     logger.info("Created asset validation diff report directory %s", output_dir)
 
@@ -422,7 +420,7 @@ def _output_asset_validation_diff_reports(
         jsonschema_err2_reps
     )
 
-    with (output_dir / summary_file_name).open("w") as summary_f:
+    with (output_dir / PYDANTIC_ERRS_SUMMARY_FNAME).open("w") as summary_f:
         # Write the summary of the Pydantic validation error differences
         summary_f.write(
             pydantic_validation_err_diff_summary(

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -563,7 +563,12 @@ def jsonschema_err_rep(
 
 def err_reps(
     rs: list[_DandisetValidationDiffReport] | list[_AssetValidationDiffReport],
-) -> tuple[Iterable[PydanticValidationErrRep], Iterable[PydanticValidationErrRep]]:
+) -> tuple[
+    Iterable[PydanticValidationErrRep],
+    Iterable[PydanticValidationErrRep],
+    Iterable[JsonschemaValidationErrRep],
+    Iterable[JsonschemaValidationErrRep],
+]:
     """
     Get all validation errors in given reports and return them in tuple presentations
     suitable for counting
@@ -580,10 +585,10 @@ def err_reps(
             of all reports
     """
 
-    # todo: expand to include jsonschema errors
-
     pydantic_err1_rep_lsts: list[list[PydanticValidationErrRep]] = []
     pydantic_err2_rep_lsts: list[list[PydanticValidationErrRep]] = []
+    jsonschema_err1_rep_lsts: list[list[JsonschemaValidationErrRep]] = []
+    jsonschema_err2_rep_lsts: list[list[JsonschemaValidationErrRep]] = []
 
     if rs:
         r0 = rs[0]
@@ -613,9 +618,18 @@ def err_reps(
             pydantic_err2_rep_lsts.append(
                 [pydantic_err_rep(e, p) for e in r.pydantic_validation_errs2]
             )
+            jsonschema_err1_rep_lsts.append(
+                [jsonschema_err_rep(e, p) for e in r.jsonschema_validation_errs1]
+            )
+            jsonschema_err2_rep_lsts.append(
+                [jsonschema_err_rep(e, p) for e in r.jsonschema_validation_errs2]
+            )
 
-    return chain.from_iterable(pydantic_err1_rep_lsts), chain.from_iterable(
-        pydantic_err2_rep_lsts
+    return (
+        chain.from_iterable(pydantic_err1_rep_lsts),
+        chain.from_iterable(pydantic_err2_rep_lsts),
+        chain.from_iterable(jsonschema_err1_rep_lsts),
+        chain.from_iterable(jsonschema_err2_rep_lsts),
     )
 
 

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -677,3 +677,16 @@ def count_pydantic_validation_errs(
     :return: A `ValidationErrCounter` object representing the counts
     """
     return count_validation_errs(err_reps_, pydantic_err_categorizer)
+
+
+def count_jsonschema_validation_errs(
+    err_reps_: Iterable[JsonschemaValidationErrRep],
+) -> ValidationErrCounter:
+    """
+    Count JSON schema validation errors provided by an iterable
+
+    :param err_reps_: The iterable of JSON schema validation errors represented as
+        tuples defined by the output of `jsonschema_err_rep`
+    :return: A `ValidationErrCounter` object representing the counts
+    """
+    return count_validation_errs(err_reps_, jsonschema_err_categorizer)

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -380,19 +380,7 @@ def _output_dandiset_validation_diff_reports(
         # files
         for r in reports:
             report_dir = output_dir / r.dandiset_identifier / r.dandiset_version
-            report_dir.mkdir(parents=True)
-
-            pydantic_errs1_base_fname = "pydantic_validation_errs1"
-            pydantic_errs2_base_fname = "pydantic_validation_errs2"
-            pydantic_errs_diff_base_fname = "pydantic_validation_errs_diff"
-
-            for data, base_fname in [
-                (r.pydantic_validation_errs1, pydantic_errs1_base_fname),
-                (r.pydantic_validation_errs2, pydantic_errs2_base_fname),
-                (r.pydantic_validation_errs_diff, pydantic_errs_diff_base_fname),
-            ]:
-                if data:
-                    write_data(data, report_dir, base_fname)
+            _output_supporting_files(r, report_dir)
 
             logger.info(
                 "Wrote dandiset %s validation diff report supporting files to %s",
@@ -451,19 +439,7 @@ def _output_asset_validation_diff_reports(
                 / r.dandiset_version
                 / str(r.asset_idx)
             )
-            report_dir.mkdir(parents=True)
-
-            pydantic_errs1_base_fname = "pydantic_validation_errs1"
-            pydantic_errs2_base_fname = "pydantic_validation_errs2"
-            pydantic_errs_diff_base_fname = "pydantic_validation_errs_diff"
-
-            for data, base_fname in [
-                (r.pydantic_validation_errs1, pydantic_errs1_base_fname),
-                (r.pydantic_validation_errs2, pydantic_errs2_base_fname),
-                (r.pydantic_validation_errs_diff, pydantic_errs_diff_base_fname),
-            ]:
-                if data:
-                    write_data(data, report_dir, base_fname)
+            _output_supporting_files(r, report_dir)
 
             logger.info(
                 "Dandiset %s:%s - asset %sat index %d: "
@@ -476,6 +452,28 @@ def _output_asset_validation_diff_reports(
             )
 
     logger.info("Output of asset validation diff reports is complete")
+
+
+def _output_supporting_files(r: _DandiValidationDiffReport, report_dir: Path) -> None:
+    """
+    Output the supporting files of an individual validation diff report
+
+    :param r: The individual validation diff report
+    :param report_dir: The directory to write the supporting files to
+    """
+    report_dir.mkdir(parents=True)
+
+    pydantic_errs1_base_fname = "pydantic_validation_errs1"
+    pydantic_errs2_base_fname = "pydantic_validation_errs2"
+    pydantic_errs_diff_base_fname = "pydantic_validation_errs_diff"
+
+    for data, base_fname in [
+        (r.pydantic_validation_errs1, pydantic_errs1_base_fname),
+        (r.pydantic_validation_errs2, pydantic_errs2_base_fname),
+        (r.pydantic_validation_errs_diff, pydantic_errs_diff_base_fname),
+    ]:
+        if data:
+            write_data(data, report_dir, base_fname)
 
 
 def pydantic_err_categorizer(

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -18,6 +18,7 @@ from dandisets_linkml_status_tools.models import (
     DandiBaseReport,
     DandisetValidationReport,
     DandisetValidationReportsType,
+    JsonschemaValidationErrorModel,
     PydanticValidationErrsType,
     ValidationReportsType,
 )
@@ -46,6 +47,7 @@ class _DandiValidationDiffReport(DandiBaseReport):
     A base class for DANDI validation diff reports
     """
 
+    # Pydantic validation errors and their diff
     pydantic_validation_errs1: Annotated[
         PydanticValidationErrsType, Field(default_factory=list)
     ]
@@ -53,6 +55,15 @@ class _DandiValidationDiffReport(DandiBaseReport):
         PydanticValidationErrsType, Field(default_factory=list)
     ]
     pydantic_validation_errs_diff: dict | list
+
+    # jsonschema validation errors and their diff
+    jsonschema_validation_errs1: Annotated[
+        list[JsonschemaValidationErrorModel], Field(default_factory=list)
+    ]
+    jsonschema_validation_errs2: Annotated[
+        list[JsonschemaValidationErrorModel], Field(default_factory=list)
+    ]
+    jsonschema_validation_errs_diff: dict | list
 
 
 class _DandisetValidationDiffReport(_DandiValidationDiffReport):

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterable
 from itertools import chain
 from pathlib import Path
 from typing import Annotated, Any, cast
@@ -570,3 +571,19 @@ def pydantic_err_rep(
         Note: The value of the `'loc'` key is converted to a tuple from a list
     """
     return err["type"], err["msg"], tuple(err["loc"]), path
+
+
+def count_pydantic_validation_errs(
+    err_reps: Iterable[tuple[str, str, tuple[str | int, ...], Path]]
+) -> ValidationErrCounter:
+    """
+    Pydantic validation errors provided by an iterable
+
+    :param err_reps: The iterable of Pydantic validation errors represented as tuples
+        defined by the output of `pydantic_err_rep`
+    :return: A `ValidationErrCounter` object representing the counts
+    """
+    ctr = ValidationErrCounter(pydantic_err_categorizer)
+    ctr.count(err_reps)
+
+    return ctr

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -505,7 +505,7 @@ def pydantic_err_categorizer(
 
 def jsonschema_err_categorizer(
     err: JsonschemaValidationErrRep,
-) -> tuple[str, tuple, tuple]:
+) -> tuple[tuple, tuple]:
     """
     Categorize a JSON schema validation error represented as a tuple
 
@@ -518,7 +518,7 @@ def jsonschema_err_categorizer(
         "[*]" if isinstance(v, int) else v for v in err_model.absolute_path
     )
 
-    return err_model.message, err_model.absolute_schema_path, categorized_absolute_path
+    return err_model.absolute_schema_path, categorized_absolute_path
 
 
 def pydantic_err_rep(err: dict[str, Any], path: Path) -> PydanticValidationErrRep:

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -25,17 +25,11 @@ from dandisets_linkml_status_tools.models import (
 )
 from dandisets_linkml_status_tools.tools import (
     create_or_replace_dir,
-    gen_header_and_alignment_rows,
     get_validation_reports_entries,
     read_reports,
     write_data,
 )
-from dandisets_linkml_status_tools.tools.md import (
-    gen_diff_cell,
-    gen_pydantic_validation_errs_cell,
-    gen_row,
-    pydantic_validation_err_diff_summary,
-)
+from dandisets_linkml_status_tools.tools.md import pydantic_validation_err_diff_summary
 from dandisets_linkml_status_tools.tools.validation_err_counter import (
     ValidationErrCounter,
 )
@@ -355,14 +349,6 @@ def _output_dandiset_validation_diff_reports(
     """
     summary_file_name = "summary.md"
 
-    summary_headers = [
-        "dandiset",
-        "version",
-        "pydantic errs 1",
-        "pydantic errs 2",
-        "pydantic errs diff",
-    ]
-
     logger.info("Creating dandiset validation diff report directory %s", output_dir)
     output_dir.mkdir(parents=True)
 
@@ -390,12 +376,8 @@ def _output_dandiset_validation_diff_reports(
             )
         )
 
-        # Write the header and alignment rows of the summary table
-        summary_f.write("\n")
-        summary_f.write(gen_header_and_alignment_rows(summary_headers))
-
         # Output individual dandiset validation diff reports by writing the supporting
-        # files and the summary table row
+        # files
         for r in reports:
             report_dir = output_dir / r.dandiset_identifier / r.dandiset_version
             report_dir.mkdir(parents=True)
@@ -417,39 +399,6 @@ def _output_dandiset_validation_diff_reports(
                 r.dandiset_identifier,
                 report_dir,
             )
-
-            # === Write the summary table row for the validation diff report ===
-            # Directory for storing all validation diff reports of the dandiset
-            dandiset_dir = f"./{r.dandiset_identifier}"
-            # Directory for storing all validation diff reports of the dandiset
-            # at a particular version
-            version_dir = f"{dandiset_dir}/{r.dandiset_version}"
-
-            row_cells = (
-                f" {c} "  # Add spaces around the cell content for better readability
-                for c in [
-                    # For the dandiset column
-                    f"[{r.dandiset_identifier}]({dandiset_dir}/)",
-                    # For the version column
-                    f"[{r.dandiset_version}]({version_dir}/)",
-                    # For the pydantic errs 1 column
-                    gen_pydantic_validation_errs_cell(
-                        r.pydantic_validation_errs1,
-                        f"{version_dir}/{pydantic_errs1_base_fname}.json",
-                    ),
-                    # For the pydantic errs 2 column
-                    gen_pydantic_validation_errs_cell(
-                        r.pydantic_validation_errs2,
-                        f"{version_dir}/{pydantic_errs2_base_fname}.json",
-                    ),
-                    # For the pydantic errs diff column
-                    gen_diff_cell(
-                        r.pydantic_validation_errs_diff,
-                        f"{version_dir}/{pydantic_errs_diff_base_fname}.json",
-                    ),
-                ]
-            )
-            summary_f.write(gen_row(row_cells))
 
     logger.info("Output of dandiset validation diff reports is complete")
 

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -457,6 +457,9 @@ def _output_asset_validation_diff_reports(
 PYDANTIC_ERRS1_BASE_FNAME = "pydantic_validation_errs1"
 PYDANTIC_ERRS2_BASE_FNAME = "pydantic_validation_errs2"
 PYDANTIC_ERRS_DIFF_BASE_FNAME = "pydantic_validation_errs_diff"
+JSONSCHEMA_ERRS1_BASE_FNAME = "jsonschema_validation_errs1"
+JSONSCHEMA_ERRS2_BASE_FNAME = "jsonschema_validation_errs2"
+JSONSCHEMA_ERRS_DIFF_BASE_FNAME = "jsonschema_validation_errs_diff"
 
 
 def _output_supporting_files(r: _DandiValidationDiffReport, report_dir: Path) -> None:
@@ -468,11 +471,20 @@ def _output_supporting_files(r: _DandiValidationDiffReport, report_dir: Path) ->
     """
     report_dir.mkdir(parents=True)
 
-    for data, base_fname in [
+    for data, base_fname in (
         (r.pydantic_validation_errs1, PYDANTIC_ERRS1_BASE_FNAME),
         (r.pydantic_validation_errs2, PYDANTIC_ERRS2_BASE_FNAME),
         (r.pydantic_validation_errs_diff, PYDANTIC_ERRS_DIFF_BASE_FNAME),
-    ]:
+        (
+            [e.model_dump(mode="json") for e in r.jsonschema_validation_errs1],
+            JSONSCHEMA_ERRS1_BASE_FNAME,
+        ),
+        (
+            [e.model_dump(mode="json") for e in r.jsonschema_validation_errs2],
+            JSONSCHEMA_ERRS2_BASE_FNAME,
+        ),
+        (r.jsonschema_validation_errs_diff, JSONSCHEMA_ERRS_DIFF_BASE_FNAME),
+    ):
         if data:
             write_data(data, report_dir, base_fname)
 

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -575,16 +575,16 @@ def pydantic_err_rep(err: dict[str, Any], path: Path) -> PydanticValidationErrRe
 
 
 def count_pydantic_validation_errs(
-    err_reps: Iterable[PydanticValidationErrRep],
+    err_reps_: Iterable[PydanticValidationErrRep],
 ) -> ValidationErrCounter:
     """
     Pydantic validation errors provided by an iterable
 
-    :param err_reps: The iterable of Pydantic validation errors represented as tuples
+    :param err_reps_: The iterable of Pydantic validation errors represented as tuples
         defined by the output of `pydantic_err_rep`
     :return: A `ValidationErrCounter` object representing the counts
     """
     ctr = ValidationErrCounter(pydantic_err_categorizer)
-    ctr.count(err_reps)
+    ctr.count(err_reps_)
 
     return ctr

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -534,6 +534,24 @@ def pydantic_err_categorizer(
     return type_, msg, loc
 
 
+def jsonschema_err_categorizer(
+    err: JsonschemaValidationErrRep,
+) -> tuple[str, tuple, tuple]:
+    """
+    Categorize a JSON schema validation error represented as a tuple
+
+    :param err: The tuple representing the JSON schema validation error
+    :return: The tuple representing the category that the error belongs to
+    """
+    err_model = err[0]
+    # Categorize the "absolute_path" by replacing all array indices with "[*]"
+    categorized_absolute_path = (
+        tuple("[*]" if isinstance(v, int) else v for v in err_model.absolute_path),
+    )
+
+    return err_model.message, err_model.absolute_schema_path, categorized_absolute_path
+
+
 def pydantic_err_rep(err: dict[str, Any], path: Path) -> PydanticValidationErrRep:
     """
     Get a representation of a Pydantic validation error as a tuple for counting

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -538,7 +538,9 @@ def _output_asset_validation_diff_reports(
     logger.info("Output of asset validation diff reports is complete")
 
 
-def pydantic_err_categorizer(err: tuple) -> tuple[str, str, tuple[str, ...]]:
+def pydantic_err_categorizer(
+    err: tuple[str, str, tuple[str | int, ...], Path]
+) -> tuple[str, str, tuple[str, ...]]:
     """
     Categorize a Pydantic validation error represented as a tuple using the same
     tuple without the path component to the dandiset at a particular version and
@@ -547,7 +549,6 @@ def pydantic_err_categorizer(err: tuple) -> tuple[str, str, tuple[str, ...]]:
     :param err: The tuple representing the Pydantic validation error
     :return: The tuple representing the category that the error belongs to
     """
-    err = cast(tuple[str, str, tuple[str | int, ...], Path], err)
     type_, msg = err[0], err[1]
 
     # Generalize the "loc" by replacing all array indices with "[*]"

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -454,6 +454,11 @@ def _output_asset_validation_diff_reports(
     logger.info("Output of asset validation diff reports is complete")
 
 
+PYDANTIC_ERRS1_BASE_FNAME = "pydantic_validation_errs1"
+PYDANTIC_ERRS2_BASE_FNAME = "pydantic_validation_errs2"
+PYDANTIC_ERRS_DIFF_BASE_FNAME = "pydantic_validation_errs_diff"
+
+
 def _output_supporting_files(r: _DandiValidationDiffReport, report_dir: Path) -> None:
     """
     Output the supporting files of an individual validation diff report
@@ -463,14 +468,10 @@ def _output_supporting_files(r: _DandiValidationDiffReport, report_dir: Path) ->
     """
     report_dir.mkdir(parents=True)
 
-    pydantic_errs1_base_fname = "pydantic_validation_errs1"
-    pydantic_errs2_base_fname = "pydantic_validation_errs2"
-    pydantic_errs_diff_base_fname = "pydantic_validation_errs_diff"
-
     for data, base_fname in [
-        (r.pydantic_validation_errs1, pydantic_errs1_base_fname),
-        (r.pydantic_validation_errs2, pydantic_errs2_base_fname),
-        (r.pydantic_validation_errs_diff, pydantic_errs_diff_base_fname),
+        (r.pydantic_validation_errs1, PYDANTIC_ERRS1_BASE_FNAME),
+        (r.pydantic_validation_errs2, PYDANTIC_ERRS2_BASE_FNAME),
+        (r.pydantic_validation_errs_diff, PYDANTIC_ERRS_DIFF_BASE_FNAME),
     ]:
         if data:
             write_data(data, report_dir, base_fname)

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -404,19 +404,13 @@ def _output_dandiset_validation_diff_reports(
             pydantic_errs2_base_fname = "pydantic_validation_errs2"
             pydantic_errs_diff_base_fname = "pydantic_validation_errs_diff"
 
-            for errs, base_fname in [
+            for data, base_fname in [
                 (r.pydantic_validation_errs1, pydantic_errs1_base_fname),
                 (r.pydantic_validation_errs2, pydantic_errs2_base_fname),
+                (r.pydantic_validation_errs_diff, pydantic_errs_diff_base_fname),
             ]:
-                if errs:
-                    write_data(errs, report_dir, base_fname)
-
-            if r.pydantic_validation_errs_diff:
-                write_data(
-                    r.pydantic_validation_errs_diff,
-                    report_dir,
-                    pydantic_errs_diff_base_fname,
-                )
+                if data:
+                    write_data(data, report_dir, base_fname)
 
             logger.info(
                 "Wrote dandiset %s validation diff report supporting files to %s",

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -376,17 +376,17 @@ def _output_dandiset_validation_diff_reports(
             )
         )
 
-        # Output individual dandiset validation diff reports by writing the supporting
-        # files
-        for r in reports:
-            report_dir = output_dir / r.dandiset_identifier / r.dandiset_version
-            _output_supporting_files(r, report_dir)
+    # Output individual dandiset validation diff reports by writing the supporting
+    # files
+    for r in reports:
+        report_dir = output_dir / r.dandiset_identifier / r.dandiset_version
+        _output_supporting_files(r, report_dir)
 
-            logger.info(
-                "Wrote dandiset %s validation diff report supporting files to %s",
-                r.dandiset_identifier,
-                report_dir,
-            )
+        logger.info(
+            "Wrote dandiset %s validation diff report supporting files to %s",
+            r.dandiset_identifier,
+            report_dir,
+        )
 
     logger.info("Output of dandiset validation diff reports is complete")
 
@@ -430,26 +430,23 @@ def _output_asset_validation_diff_reports(
             )
         )
 
-        # Output individual asset validation diff reports by writing the constituting
-        # files
-        for r in reports:
-            report_dir = (
-                output_dir
-                / r.dandiset_identifier
-                / r.dandiset_version
-                / str(r.asset_idx)
-            )
-            _output_supporting_files(r, report_dir)
+    # Output individual asset validation diff reports by writing the constituting
+    # files
+    for r in reports:
+        report_dir = (
+            output_dir / r.dandiset_identifier / r.dandiset_version / str(r.asset_idx)
+        )
+        _output_supporting_files(r, report_dir)
 
-            logger.info(
-                "Dandiset %s:%s - asset %sat index %d: "
-                "Wrote asset validation diff report constituting files to %s",
-                r.dandiset_identifier,
-                r.dandiset_version,
-                f"{r.asset_id} " if r.asset_id else "",
-                r.asset_idx,
-                report_dir,
-            )
+        logger.info(
+            "Dandiset %s:%s - asset %sat index %d: "
+            "Wrote asset validation diff report constituting files to %s",
+            r.dandiset_identifier,
+            r.dandiset_version,
+            f"{r.asset_id} " if r.asset_id else "",
+            r.asset_idx,
+            report_dir,
+        )
 
     logger.info("Output of asset validation diff reports is complete")
 

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -43,6 +43,7 @@ from dandisets_linkml_status_tools.tools.validation_err_counter import (
 logger = logging.getLogger(__name__)
 
 PydanticValidationErrRep: TypeAlias = tuple[str, str, tuple[str | int, ...], Path]
+JsonschemaValidationErrRep: TypeAlias = tuple[JsonschemaValidationErrorModel, Path]
 
 
 class _DandiValidationDiffReport(DandiBaseReport):
@@ -544,6 +545,20 @@ def pydantic_err_rep(err: dict[str, Any], path: Path) -> PydanticValidationErrRe
         Note: The value of the `'loc'` key is converted to a tuple from a list
     """
     return err["type"], err["msg"], tuple(err["loc"]), path
+
+
+def jsonschema_err_rep(
+    err: JsonschemaValidationErrorModel, path: Path
+) -> JsonschemaValidationErrRep:
+    """
+    Get a representation of a JSON schema validation error as a tuple for counting
+
+    :param err: The JSON schema validation error
+    :param path: The path the data instance that the error pertained to
+    :return: The representation of the JSON schema validation error as tuple consisting
+        of the error and `path`
+    """
+    return err, path
 
 
 def err_reps(

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -366,10 +366,21 @@ def _output_dandiset_validation_diff_reports(
     logger.info("Creating dandiset validation diff report directory %s", output_dir)
     output_dir.mkdir(parents=True)
 
-    pydantic_err1_reps, pydantic_err2_reps = err_reps(reports)
+    (
+        pydantic_err1_reps,
+        pydantic_err2_reps,
+        jsonschema_err1_reps,
+        jsonschema_err2_reps,
+    ) = err_reps(reports)
 
     pydantic_validation_errs1_ctr = count_pydantic_validation_errs(pydantic_err1_reps)
     pydantic_validation_errs2_ctr = count_pydantic_validation_errs(pydantic_err2_reps)
+    jsonschema_validation_errs1_ctr = count_jsonschema_validation_errs(
+        jsonschema_err1_reps
+    )
+    jsonschema_validation_errs2_ctr = count_jsonschema_validation_errs(
+        jsonschema_err2_reps
+    )
 
     with (output_dir / summary_file_name).open("w") as summary_f:
         # Write the summary of the Pydantic validation error differences
@@ -464,10 +475,21 @@ def _output_asset_validation_diff_reports(
     output_dir.mkdir(parents=True)
     logger.info("Created asset validation diff report directory %s", output_dir)
 
-    pydantic_err1_reps, pydantic_err2_reps = err_reps(reports)
+    (
+        pydantic_err1_reps,
+        pydantic_err2_reps,
+        jsonschema_err1_reps,
+        jsonschema_err2_reps,
+    ) = err_reps(reports)
 
     pydantic_validation_errs1_ctr = count_pydantic_validation_errs(pydantic_err1_reps)
     pydantic_validation_errs2_ctr = count_pydantic_validation_errs(pydantic_err2_reps)
+    jsonschema_validation_errs1_ctr = count_jsonschema_validation_errs(
+        jsonschema_err1_reps
+    )
+    jsonschema_validation_errs2_ctr = count_jsonschema_validation_errs(
+        jsonschema_err2_reps
+    )
 
     with (output_dir / summary_file_name).open("w") as summary_f:
         # Write the summary of the Pydantic validation error differences

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -365,24 +365,10 @@ def _output_dandiset_validation_diff_reports(
     logger.info("Creating dandiset validation diff report directory %s", output_dir)
     output_dir.mkdir(parents=True)
 
-    err1_rep_lsts: list[list[PydanticValidationErrRep]] = []
-    err2_rep_lsts: list[list[PydanticValidationErrRep]] = []
-    for r in reports:
-        p = Path(r.dandiset_identifier, r.dandiset_version)
+    pydantic_err1_reps, pydantic_err2_reps = err_reps(reports)
 
-        # Tuple representation of the Pydantic validation errors
-        err1_rep_lsts.append(
-            [pydantic_err_rep(e, p) for e in r.pydantic_validation_errs1]
-        )
-        err2_rep_lsts.append(
-            [pydantic_err_rep(e, p) for e in r.pydantic_validation_errs2]
-        )
-
-    pydantic_validation_errs1_ctr = ValidationErrCounter(pydantic_err_categorizer)
-    pydantic_validation_errs2_ctr = ValidationErrCounter(pydantic_err_categorizer)
-
-    pydantic_validation_errs1_ctr.count(chain.from_iterable(err1_rep_lsts))
-    pydantic_validation_errs2_ctr.count(chain.from_iterable(err2_rep_lsts))
+    pydantic_validation_errs1_ctr = count_pydantic_validation_errs(pydantic_err1_reps)
+    pydantic_validation_errs2_ctr = count_pydantic_validation_errs(pydantic_err2_reps)
 
     with (output_dir / summary_file_name).open("w") as summary_f:
         # Write the summary of the Pydantic validation error differences
@@ -477,24 +463,10 @@ def _output_asset_validation_diff_reports(
     output_dir.mkdir(parents=True)
     logger.info("Created asset validation diff report directory %s", output_dir)
 
-    err1_rep_lsts: list[list[PydanticValidationErrRep]] = []
-    err2_rep_lsts: list[list[PydanticValidationErrRep]] = []
-    for r in reports:
-        p = Path(r.dandiset_identifier, r.dandiset_version, str(r.asset_idx))
+    pydantic_err1_reps, pydantic_err2_reps = err_reps(reports)
 
-        # Tuple representation of the Pydantic validation errors
-        err1_rep_lsts.append(
-            [pydantic_err_rep(e, p) for e in r.pydantic_validation_errs1]
-        )
-        err2_rep_lsts.append(
-            [pydantic_err_rep(e, p) for e in r.pydantic_validation_errs2]
-        )
-
-    pydantic_validation_errs1_ctr = ValidationErrCounter(pydantic_err_categorizer)
-    pydantic_validation_errs2_ctr = ValidationErrCounter(pydantic_err_categorizer)
-
-    pydantic_validation_errs1_ctr.count(chain.from_iterable(err1_rep_lsts))
-    pydantic_validation_errs2_ctr.count(chain.from_iterable(err2_rep_lsts))
+    pydantic_validation_errs1_ctr = count_pydantic_validation_errs(pydantic_err1_reps)
+    pydantic_validation_errs2_ctr = count_pydantic_validation_errs(pydantic_err2_reps)
 
     with (output_dir / summary_file_name).open("w") as summary_f:
         # Write the summary of the Pydantic validation error differences

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -42,7 +42,7 @@ from dandisets_linkml_status_tools.tools.validation_err_counter import (
 
 logger = logging.getLogger(__name__)
 
-PydanticValidationErrRep: TypeAlias = tuple[str, str, tuple[str | int, ...], Path]
+PydanticValidationErrRep: TypeAlias = tuple[str, str, tuple, Path]
 JsonschemaValidationErrRep: TypeAlias = tuple[JsonschemaValidationErrorModel, Path]
 
 

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -44,6 +44,7 @@ PydanticValidationErrRep: TypeAlias = tuple[str, str, tuple, Path]
 JsonschemaValidationErrRep: TypeAlias = tuple[JsonschemaValidationErrorModel, Path]
 
 PYDANTIC_ERRS_SUMMARY_FNAME = "pydantic_errs_summary.md"
+JSONSCHEMA_ERRS_SUMMARY_FNAME = "jsonschema_errs_summary.md"
 
 
 class _DandiValidationDiffReport(DandiBaseReport):
@@ -385,9 +386,12 @@ def _output_dandiset_validation_diff_reports(
 
     with (output_dir / JSONSCHEMA_ERRS_SUMMARY_FNAME).open("w") as summary_f:
         # Write the summary of the JSON schema validation error differences
+        # noinspection PyTypeChecker
         summary_f.write(
-            pydantic_validation_err_diff_summary(
-                pydantic_validation_errs1_ctr, pydantic_validation_errs2_ctr
+            validation_err_diff_summary(
+                jsonschema_validation_errs1_ctr,
+                jsonschema_validation_errs2_ctr,
+                jsonschema_validation_err_diff_detailed_table,
             )
         )
 
@@ -445,6 +449,15 @@ def _output_asset_validation_diff_reports(
                 pydantic_validation_err_diff_detailed_table,
             )
         )
+
+    with (output_dir / JSONSCHEMA_ERRS_SUMMARY_FNAME).open("w") as summary_f:
+        # Write the summary of the JSON schema validation error differences
+        # noinspection PyTypeChecker
+        summary_f.write(
+            validation_err_diff_summary(
+                jsonschema_validation_errs1_ctr,
+                jsonschema_validation_errs2_ctr,
+                jsonschema_validation_err_diff_detailed_table,
             )
         )
 

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -536,7 +536,7 @@ def pydantic_err_categorizer(
 
 def pydantic_err_rep(err: dict[str, Any], path: Path) -> PydanticValidationErrRep:
     """
-    Get a representation of a Pydantic validation error as a tuple
+    Get a representation of a Pydantic validation error as a tuple for counting
 
     :param err: The Pydantic validation error as a `dict`
     :param path: The path the data instance that the error pertained to

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Iterable
 from itertools import chain
 from pathlib import Path
-from typing import Annotated, Any, cast
+from typing import Annotated, Any, TypeAlias, cast
 
 from jsondiff import diff
 from pydantic import Field
@@ -41,6 +41,8 @@ from dandisets_linkml_status_tools.tools.validation_err_counter import (
 )
 
 logger = logging.getLogger(__name__)
+
+PydanticValidationErrRep: TypeAlias = tuple[str, str, tuple[str | int, ...], Path]
 
 
 class _DandiValidationDiffReport(DandiBaseReport):
@@ -363,8 +365,8 @@ def _output_dandiset_validation_diff_reports(
     logger.info("Creating dandiset validation diff report directory %s", output_dir)
     output_dir.mkdir(parents=True)
 
-    err1_rep_lsts: list[list[tuple[str, str, tuple[str | int, ...], Path]]] = []
-    err2_rep_lsts: list[list[tuple[str, str, tuple[str | int, ...], Path]]] = []
+    err1_rep_lsts: list[list[PydanticValidationErrRep]] = []
+    err2_rep_lsts: list[list[PydanticValidationErrRep]] = []
     for r in reports:
         p = Path(r.dandiset_identifier, r.dandiset_version)
 
@@ -475,8 +477,8 @@ def _output_asset_validation_diff_reports(
     output_dir.mkdir(parents=True)
     logger.info("Created asset validation diff report directory %s", output_dir)
 
-    err1_rep_lsts: list[list[tuple[str, str, tuple[str | int, ...], Path]]] = []
-    err2_rep_lsts: list[list[tuple[str, str, tuple[str | int, ...], Path]]] = []
+    err1_rep_lsts: list[list[PydanticValidationErrRep]] = []
+    err2_rep_lsts: list[list[PydanticValidationErrRep]] = []
     for r in reports:
         p = Path(r.dandiset_identifier, r.dandiset_version, str(r.asset_idx))
 
@@ -539,7 +541,7 @@ def _output_asset_validation_diff_reports(
 
 
 def pydantic_err_categorizer(
-    err: tuple[str, str, tuple[str | int, ...], Path]
+    err: PydanticValidationErrRep,
 ) -> tuple[str, str, tuple[str, ...]]:
     """
     Categorize a Pydantic validation error represented as a tuple using the same
@@ -559,9 +561,7 @@ def pydantic_err_categorizer(
     return type_, msg, loc
 
 
-def pydantic_err_rep(
-    err: dict[str, Any], path: Path
-) -> tuple[str, str, tuple[str | int, ...], Path]:
+def pydantic_err_rep(err: dict[str, Any], path: Path) -> PydanticValidationErrRep:
     """
     Get a representation of a Pydantic validation error as a tuple
 
@@ -575,7 +575,7 @@ def pydantic_err_rep(
 
 
 def count_pydantic_validation_errs(
-    err_reps: Iterable[tuple[str, str, tuple[str | int, ...], Path]]
+    err_reps: Iterable[PydanticValidationErrRep],
 ) -> ValidationErrCounter:
     """
     Pydantic validation errors provided by an iterable

--- a/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
+++ b/src/dandisets_linkml_status_tools/cmd_funcs/diff_manifests_reports.py
@@ -515,7 +515,7 @@ def _output_asset_validation_diff_reports(
 
 def pydantic_err_categorizer(
     err: PydanticValidationErrRep,
-) -> tuple[str, str, tuple[str, ...]]:
+) -> tuple[str, str, tuple]:
     """
     Categorize a Pydantic validation error represented as a tuple using the same
     tuple without the path component to the dandiset at a particular version and
@@ -526,12 +526,10 @@ def pydantic_err_categorizer(
     """
     type_, msg = err[0], err[1]
 
-    # Generalize the "loc" by replacing all array indices with "[*]"
-    loc = cast(
-        tuple[str, ...], tuple("[*]" if isinstance(v, int) else v for v in err[2])
-    )
+    # Categorize the "loc" by replacing all array indices with "[*]"
+    categorized_loc = tuple("[*]" if isinstance(v, int) else v for v in err[2])
 
-    return type_, msg, loc
+    return type_, msg, categorized_loc
 
 
 def jsonschema_err_categorizer(

--- a/src/dandisets_linkml_status_tools/tools/md.py
+++ b/src/dandisets_linkml_status_tools/tools/md.py
@@ -284,57 +284,57 @@ def pydantic_validation_err_diff_detailed_table(
     return f"{heading}{header_and_alignment_rows}{rows}"
 
 
-def pydantic_validation_err_diff_summary(
-    c1: ValidationErrCounter, c2: ValidationErrCounter
+def validation_err_diff_summary(
+    c1: ValidationErrCounter,
+    c2: ValidationErrCounter,
+    detailed_tb_func: DetailedTableGenerator,
 ) -> str:
     """
-    Generate a summary of the differences between two sets of Pydantic validation errors
+    Generate a summary of the differences between two sets of validation errors
 
-    :param c1: A `ValidationErrCounter` that has counted the first set of Pydantic
-        validation errors
-    :param c2: A `ValidationErrCounter` that has counted the second set of Pydantic
-        validation errors
+    :param c1: A `ValidationErrCounter` that has counted the first set of validation
+        errors
+    :param c2: A `ValidationErrCounter` that has counted the second set of validation
+        errors
+    :param detailed_tb_func: The function that generates a table detailing the
+        differences in a specific category of validation errors
     :return: The string presenting the summary in Markdown format
     """
 
-    # The base name of the anchor of the detailed tables of categories of Pydantic
-    # validation errors
+    # The base name of the anchor of the detailed tables of categories of validation
+    # errors
     detailed_tb_base_anchor = "cat"
 
-    # The differences in the different categories of
-    # Pydantic validation errors between the two sets of validation results where
+    # The differences in the different categories of validation errors between the two
+    # sets of validation results where
     # each set is represented, and counted, by a `ValidationErrCounter` object
-    pydantic_validation_err_diff = validation_err_diff(c1, c2)
+    err_diff = validation_err_diff(c1, c2)
     detailed_tb_anchors = {
-        cat: f"{detailed_tb_base_anchor}-{i}"
-        for i, cat in enumerate(sorted(pydantic_validation_err_diff))
+        cat: f"{detailed_tb_base_anchor}-{i}" for i, cat in enumerate(sorted(err_diff))
     }
 
     count_table1 = validation_err_count_table(c1.counts_by_cat)
     count_table2 = validation_err_count_table(c2.counts_by_cat)
 
-    # A table of the differences in the different categories of Pydantic validation
-    # errors
-    diff_table = validation_err_diff_table(
-        pydantic_validation_err_diff, detailed_tb_anchors
-    )
+    # A table of the differences in the different categories of validation errors
+    diff_table = validation_err_diff_table(err_diff, detailed_tb_anchors)
 
-    # A sequence of tables detailing the differences in Pydantic validation
-    # errors between the two sets of validation results
+    # A sequence of tables detailing the differences in validation errors between the
+    # two sets of validation results
     # noinspection PyTypeChecker
     diff_detailed_tables = validation_err_diff_detailed_tables(
-        pydantic_validation_err_diff,
-        pydantic_validation_err_diff_detailed_table,
+        err_diff,
+        detailed_tb_func,
         detailed_tb_anchors,
     )
 
     return (
-        f"### Pydantic errs 1 counts\n\n"
+        f"### errs 1 counts\n\n"
         f"{count_table1}"
-        f"\n### Pydantic errs 2 counts\n\n"
+        f"\n### errs 2 counts\n\n"
         f"{count_table2}"
-        f"\n### Pydantic errs diff\n\n"
+        f"\n### errs diff\n\n"
         f"{diff_table}"
-        f"\n## Pydantic errs diff detailed tables\n\n"
+        f"\n## errs diff detailed tables\n\n"
         f"{diff_detailed_tables}"
     )

--- a/src/dandisets_linkml_status_tools/tools/md.py
+++ b/src/dandisets_linkml_status_tools/tools/md.py
@@ -284,6 +284,63 @@ def pydantic_validation_err_diff_detailed_table(
     return f"{heading}{header_and_alignment_rows}{rows}"
 
 
+def jsonschema_validation_err_diff_detailed_table(
+    cat: tuple, diff: Counter[tuple], *, is_removed: bool
+) -> str:
+    """
+    Generate a table for a specific category of JSON schema validation errors
+
+    :param cat: The category of the JSON schema validation errors
+    :param diff: The differences of JSON schema validation errors in the given category
+        represented as a `Counter` object
+    :param is_removed: A boolean value indicating whether `diff` represents the
+        validation errors removed or gained
+    :return: The string presenting the table in Markdown format
+    """
+    # Header of the count column
+    count_col_header = "Removed" if is_removed else "Gained"
+
+    heading = f"### {escape(str(cat))}\n\n"
+    header_and_alignment_rows = gen_header_and_alignment_rows(
+        (
+            "message",
+            "absolute_schema_path",
+            "absolute_path",
+            "Data instance path",
+            count_col_header,
+        )
+    )
+
+    rows = "".join(
+        gen_row(
+            (
+                # The "message" attribute of the JSON schema validation error
+                escape(err_model.message),
+                # The "absolute_schema_path" attribute of the JSON schema validation error
+                escape(str(err_model.absolute_schema_path)),
+                # The "absolute_path" attribute of the JSON schema validation error
+                escape(str(err_model.absolute_path)),
+                # The path of the data instance
+                f"[{instance_path}]({instance_path})",
+                # The count of removed or gained of the represented error
+                count,
+            )
+        )
+        for (err_model, instance_path), count in sorted(
+            diff.items(),
+            key=lambda i: (
+                i[0][0].message,
+                i[0][0].absolute_schema_path,
+                i[0][0].absolute_path,
+                i[0][1],
+                i[1],
+            ),
+        )
+    )
+
+    return f"{heading}{header_and_alignment_rows}{rows}"
+
+
 def validation_err_diff_summary(
     c1: ValidationErrCounter,
     c2: ValidationErrCounter,

--- a/src/dandisets_linkml_status_tools/tools/validation_err_counter.py
+++ b/src/dandisets_linkml_status_tools/tools/validation_err_counter.py
@@ -1,10 +1,11 @@
 from collections import Counter, defaultdict
 from collections.abc import Callable, Iterable
+from typing import Any
 
 
 class ValidationErrCounter:
 
-    def __init__(self, err_categorizer: Callable[[tuple], tuple]):
+    def __init__(self, err_categorizer: Callable[[Any], tuple]):
         """
         Initialize the validation error counter
 

--- a/src/dandisets_linkml_status_tools/tools/validation_err_counter.py
+++ b/src/dandisets_linkml_status_tools/tools/validation_err_counter.py
@@ -87,10 +87,9 @@ def validation_err_diff(
     :return: A dictionary presenting the diff between the two objects. The keys are the
         keys in `c1` or `c2` that represent a category of validation errors in which
         there is a difference `c1` and `c2`. The values are a tuple consisting of a
-        `Counter` object representing the validation errors removed from `c1` when
-        compared to `c2` in the corresponding error category and a `Counter` object
-        representing the validation errors gained in `c2` when compared to `c1` in the
-        corresponding error category
+        `Counter` object representing the validation errors removed and a `Counter`
+        object representing the validation errors gained when comparing between `c1` and
+        `c2` in the corresponding error category
     """
     cats = c1.cats().union(c2.cats())
 


### PR DESCRIPTION
Add support of generating diff reports for jsonschema validation errors to the `diff-manifests-reports` subcommand.

Additionally, this PR removes table for error diff at each dandiset.