### PR TITLE
Add SHACL and OWL representations of the generated DANDI LinkML schema to generated reports

### DIFF
--- a/src/dandisets_linkml_status_tools/tools/__init__.py
+++ b/src/dandisets_linkml_status_tools/tools/__init__.py
@@ -7,7 +7,9 @@ from functools import partial
 from itertools import chain
 from pathlib import Path
 from shutil import rmtree
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, Literal
+from linkml.generators.shaclgen import ShaclGenerator
+from linkml.generators.owlgen import OwlSchemaGenerator
 
 from dandi.dandiapi import RemoteDandiset
 from dandischema.models import Dandiset, PublishedDandiset
@@ -182,6 +184,24 @@ class DandiModelLinkmlValidator:
             dandi_metadata, target_class=dandi_metadata_class
         )
         return validation_report.results
+
+
+def gen_dandi_linkml_schema_rep(fmt: Literal["owl", "shacl"]) -> str:
+    """
+    Generate a representation of the DANDI LinkML schema in a specified format
+
+    :param fmt: The format of the representation to be generated.
+        Must be either `"owl"` or `"shacl"`.
+    :return: The generated representation as a string
+    """
+    if fmt == "owl":
+        generator = OwlSchemaGenerator(
+            DandiModelLinkmlValidator.get_dandi_linkml_schema()
+        )
+    else:
+        generator = ShaclGenerator(DandiModelLinkmlValidator.get_dandi_linkml_schema())
+
+    return generator.serialize()
 
 
 def compile_dandiset_linkml_translation_report(

--- a/src/dandisets_linkml_status_tools/tools/__init__.py
+++ b/src/dandisets_linkml_status_tools/tools/__init__.py
@@ -384,6 +384,24 @@ def output_dandi_linkml_schema(output_path: Path) -> None:
     logger.info("Output the DANDI LinkML schema to %s", output_path)
 
 
+def output_dandi_linkml_schema_rep(
+    output_path: Path, fmt: Literal["owl", "shacl"]
+) -> None:
+    """
+    Output the DANDI LinkML schema representation, in a specified format, to a file
+
+    :param output_path: The path specifying the location of the file
+    :param fmt: The format of the representation to be output.
+        Must be either `"owl"` or `"shacl"`.
+    """
+    output_path.write_text(gen_dandi_linkml_schema_rep(fmt))
+    logger.info(
+        "Output the DANDI LinkML schema representation in %s format to %s",
+        fmt,
+        output_path,
+    )
+
+
 def output_reports(
     reports: list[DandisetLinkmlTranslationReport], output_path: Path
 ) -> None:
@@ -406,6 +424,9 @@ def output_reports(
 
     dandi_linkml_schema_base_fname = "dandi-linkml-schema"
     dandi_linkml_schema_fname = f"{dandi_linkml_schema_base_fname}.yml"
+    dandi_linkml_schema_owl_rep_fname = f"{dandi_linkml_schema_base_fname}.owl.ttl "
+    dandi_linkml_schema_shacl_rep_fname = f"{dandi_linkml_schema_base_fname}.shacl.ttl"
+
     summary_headers = [
         "dandiset",
         "version",
@@ -420,12 +441,21 @@ def output_reports(
     create_or_replace_dir(output_path)
 
     output_dandi_linkml_schema(output_path / dandi_linkml_schema_fname)
+    # Output the DANDI LinkML schema representations in different formats
+    output_dandi_linkml_schema_rep(
+        output_path / dandi_linkml_schema_owl_rep_fname, "owl"
+    )
+    output_dandi_linkml_schema_rep(
+        output_path / dandi_linkml_schema_shacl_rep_fname, "shacl"
+    )
 
     with (output_path / summary_file_name).open("w") as summary_f:
         # === Provide a reference to the DANDI LinkML schema in the summary ===
         summary_f.write(
             f"[DANDI LinkML schema](./{dandi_linkml_schema_fname}) "
             f"(LinkML schema used in the LinkML validations)\n"
+            f"[DANDI LinkML schema as OWL](./{dandi_linkml_schema_owl_rep_fname})\n"
+            f"[DANDI LinkML schema as SHACL](./{dandi_linkml_schema_shacl_rep_fname})\n"
         )
 
         # Write line break before the start of the summary table

--- a/src/dandisets_linkml_status_tools/tools/__init__.py
+++ b/src/dandisets_linkml_status_tools/tools/__init__.py
@@ -383,7 +383,9 @@ def output_reports(
     raises NotADirectoryError: If the given output path points to a non-directory object
     """
     summary_file_name = "summary.md"
-    dandi_linkml_schema_file_name = "dandi-linkml-schema.yml"
+
+    dandi_linkml_schema_base_fname = "dandi-linkml-schema"
+    dandi_linkml_schema_fname = f"{dandi_linkml_schema_base_fname}.yml"
     summary_headers = [
         "dandiset",
         "version",
@@ -397,12 +399,12 @@ def output_reports(
     logger.info("Creating report directory: %s", output_path)
     create_or_replace_dir(output_path)
 
-    output_dandi_linkml_schema(output_path / dandi_linkml_schema_file_name)
+    output_dandi_linkml_schema(output_path / dandi_linkml_schema_fname)
 
     with (output_path / summary_file_name).open("w") as summary_f:
         # === Provide a reference to the DANDI LinkML schema in the summary ===
         summary_f.write(
-            f"[DANDI LinkML schema](./{dandi_linkml_schema_file_name}) "
+            f"[DANDI LinkML schema](./{dandi_linkml_schema_fname}) "
             f"(LinkML schema used in the LinkML validations)\n"
         )
 


### PR DESCRIPTION
This PR adds SHACL and OWL representations of the generated DANDI LinkML schema to the generated reports by the `linkml-translation` subcommand. The representations produced using LinkML's support to [SHACL](https://linkml.io/linkml/generators/shacl.html) and [OWL](https://linkml.io/linkml/generators/owl.html) respectively.

This PR closes https://github.com/dandi/dandisets-linkml-status/issues/11.